### PR TITLE
CLA bot action fixes

### DIFF
--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -13,16 +13,14 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Contributor License Agreement and I hereby accept the Terms.') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.1.3-beta
+        uses: cla-assistant/github-action@v2.3.0
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN : ${{ secrets.REPO_BOT_ACCESS_TOKEN }}
         with:
-          remote-organization-name: oqc-community
-          remote-repository-name: qat
           branch: 'bot/data'
           path-to-signatures: 'cla.json'
           custom-allsigned-prcomment: 'All Contributors have signed the CLA.'
           custom-pr-sign-comment: 'I have read the Contributor License Agreement and I hereby accept the Terms.'
-          allowlist: user1,bot*
+          allowlist: bot*
           path-to-document: 'https://github.com/oqc-community/qat/blob/main/contributor_license_agreement.md'


### PR DESCRIPTION
Adjusted misconfigured variables to the CLA assistant bot and added OQC QAT team members to the allow list so that we do not have to sign the CLA when contributing.
The fix won't take affect until merged, there is however a test PR in the private repo showing it working.