### PR TITLE
Default primary IRs to results distriubution

### DIFF
--- a/src/QAT/qat/purr/compiler/config.py
+++ b/src/QAT/qat/purr/compiler/config.py
@@ -381,13 +381,35 @@ def get_optimizer_config(lang: Languages) -> Optional[OptimizationConfig]:
     return None
 
 
-def get_config(lang: Languages, **kwargs):
+_default_results_format = QuantumResultsFormat()
+
+
+def default_language_options(lang: Languages, config: CompilerConfig):
+    """ Applies default language-specific options to an existing configuration. """
+    if lang == Languages.Qasm2:
+        if config.optimizations is None:
+            config.optimizations = Qasm2Optimizations()
+        if config.results_format == _default_results_format:
+            config.results_format.binary_count()
+
+    elif lang == Languages.Qasm3:
+        if config.optimizations is None:
+            config.optimizations = Qasm3Optimizations()
+
+    elif lang == Languages.QIR:
+        if config.optimizations is None:
+            config.optimizations = QIROptimizations()
+        if config.results_format == _default_results_format:
+            config.results_format.binary_count()
+
+
+def get_default_config(lang: Languages, **kwargs):
     """
     Helper method to build a compiler config for a particular language. Forwards
     keywords to the CompilerConfig constructor.
     """
     config = CompilerConfig(**kwargs)
-    config.optimizations = get_optimizer_config(lang)
+    default_language_options(lang, config)
     return config
 
 

--- a/src/QAT/qat/purr/compiler/frontends.py
+++ b/src/QAT/qat/purr/compiler/frontends.py
@@ -9,7 +9,7 @@ from typing import Tuple, Union
 
 import regex
 from qat.purr.compiler.builders import InstructionBuilder
-from qat.purr.compiler.config import CompilerConfig, Languages, get_optimizer_config
+from qat.purr.compiler.config import CompilerConfig, Languages, get_optimizer_config, default_language_options
 from qat.purr.compiler.execution import QuantumExecutionEngine
 from qat.purr.compiler.hardware_models import QuantumHardwareModel
 from qat.purr.compiler.metrics import CompilationMetrics
@@ -86,8 +86,7 @@ class QIRFrontend(LanguageFrontend):
         metrics = CompilationMetrics()
         metrics.initialize(compiler_config.metrics)
 
-        if compiler_config.optimizations is None:
-            compiler_config.optimizations = get_optimizer_config(Languages.QIR)
+        default_language_options(Languages.QIR, compiler_config)
 
         model = get_model(hardware)
 
@@ -138,10 +137,7 @@ class QASMFrontend(LanguageFrontend):
         metrics.initialize(compiler_config.metrics)
 
         parser = get_qasm_parser(qasm_string)
-        if compiler_config.optimizations is None:
-            compiler_config.optimizations = get_optimizer_config(
-                parser.parser_language()
-            )
+        default_language_options(parser.parser_language(), compiler_config)
 
         with log_duration("Compilation completed, took {} seconds."):
             log.info(

--- a/src/tests/test_qasm.py
+++ b/src/tests/test_qasm.py
@@ -442,7 +442,7 @@ class TestExecutionFrontend:
 
         assert results is not None
         assert len(results) == 1
-        assert len(results["c"]) == 2
+        assert results["c"]["00"] == 1000
 
     def test_quality_couplings_all_off(self):
         qasm_string = get_qasm2("basic.qasm")
@@ -464,7 +464,7 @@ class TestExecutionFrontend:
 
         assert results is not None
         assert len(results) == 1
-        assert len(results["c"]) == 2
+        assert results["c"]["00"] == 1000
 
     @pytest.mark.skip(
         "Tket incorrectly fails verification with remapping off. Assert this is wrong, "
@@ -512,7 +512,7 @@ class TestExecutionFrontend:
 
         assert len(results) == 1
         assert "c" in results
-        assert results["c"] == [1, 1]
+        assert results["c"]["11"] > 700
 
     def test_engine_as_model(self):
         qasm_string = get_qasm2("ghz.qasm")
@@ -521,7 +521,7 @@ class TestExecutionFrontend:
 
         assert len(results) == 1
         assert "b" in results
-        assert results["b"] == [0, 0, 0, 0]
+        assert results["b"]["0000"] == 1000
 
     def test_ghz(self):
         qasm_string = get_qasm2("ghz.qasm")
@@ -529,7 +529,7 @@ class TestExecutionFrontend:
         results = execute_qasm(qasm_string, hardware)
         assert len(results) == 1
         assert "b" in results
-        assert results["b"] == [0, 0, 0, 0]
+        assert results["b"]["0000"] == 1000
 
     def test_basic_binary(self):
         qasm_string = get_qasm2("basic_results_formats.qasm")
@@ -538,9 +538,8 @@ class TestExecutionFrontend:
         assert len(results) == 2
         assert "ab" in results
         assert "c" in results
-        assert results["ab"] == [0, 0]
-        assert results["c"][1] == 0
-        assert results["c"][0] in (1, 0)
+        assert results["ab"]["00"] == 1000
+        assert results["c"]["00"] == 1000
 
     @pytest.mark.skipif(
         not qutip_available, reason="Qutip is not available on this platform"
@@ -567,7 +566,7 @@ class TestExecutionFrontend:
         hardware = get_default_echo_hardware(3)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["meas"] == [0, 0]
+        assert results["meas"]["00"] == 1000
 
     def test_device_revert(self):
         hw = get_default_echo_hardware(4)
@@ -590,15 +589,15 @@ class TestExecutionFrontend:
         hardware = get_default_echo_hardware(2)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["meas"] == [0, 0]
+        assert results["meas"]["00"] == 1000
 
     def test_example(self):
         qasm_string = get_qasm2("example.qasm")
         hardware = get_default_echo_hardware(9)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 2
-        assert results["c"] == [0, 0, 0]
-        assert results["d"] == [0, 0, 0]
+        assert results["c"]["000"] == 1000
+        assert results["d"]["000"] == 1000
 
     def test_example_if(self):
         qasm_string = get_qasm2("example_if.qasm")
@@ -611,7 +610,7 @@ class TestExecutionFrontend:
         hardware = get_default_echo_hardware(2)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["c"] == [0, 0]
+        assert results["c"]["00"] == 1000
 
     def test_mid_circuit_measure(self):
         qasm_string = get_qasm2("invalid_mid_circuit_measure.qasm")
@@ -624,37 +623,37 @@ class TestExecutionFrontend:
         hardware = get_default_echo_hardware(6)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["c"] == [0, 0]
+        assert results["c"]["00"] == 1000
 
     def test_move_measurements(self):
         qasm_string = get_qasm2("move_measurements.qasm")
         hardware = get_default_echo_hardware(12)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["c"] == [0, 0, 0]
+        assert results["c"]["000"] == 1000
 
     def test_order_cregs(self):
         qasm_string = get_qasm2("ordered_cregs.qasm")
         hardware = get_default_echo_hardware(4)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 3
-        assert results["a"] == [0, 0]
-        assert results["b"] == [0, 0]
-        assert results["c"] == [0, 0]
+        assert results["a"]["00"] == 1000
+        assert results["b"]["00"] == 1000
+        assert results["c"]["00"] == 1000
 
     def test_parallel_test(self):
         qasm_string = get_qasm2("parallel_test.qasm")
         hardware = get_default_echo_hardware(10)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["c0"] == [0, 0]
+        assert results["c0"]["00"] == 1000
 
     def test_random_n5_d5(self):
         qasm_string = get_qasm2("random_n5_d5.qasm")
         hardware = get_default_echo_hardware(5)
         results = execute_qasm(qasm_string, hardware=hardware)
         assert len(results) == 1
-        assert results["c"] == [0, 0, 0, 0, 0]
+        assert results["c"]["00000"] == 1000
 
     def test_metrics_filtered(self):
         metrics = CompilationMetrics(MetricsType.Empty)
@@ -691,7 +690,7 @@ class TestExecutionFrontend:
         results = execute_qasm(qasm_string)
         assert results is not None
         assert len(results) == 1
-        assert len(results["c"]) == 2
+        assert results["c"]["00"] == 1000
 
     @pytest.mark.skipif(
         not qutip_available, reason="Qutip is not available on this platform"
@@ -732,7 +731,7 @@ class TestExecutionFrontend:
 
         # We're testing that individual assignments to a classical register get
         # correctly assigned, aka that measuring c[0] then c[1] results in c = [c0, c1].
-        assert len(results["c"]) == 2
+        assert results["c"]["00"] == 1000
 
     def test_frontend_peek(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Both QASM and QIRs default assumptions are you want a results distribution. QIR didn't have one so switch that over, QASM had a very old binary coercion.