### PR TITLE
Allow instructions to be returned as a metric

### DIFF
--- a/src/QAT/qat/purr/compiler/config.py
+++ b/src/QAT/qat/purr/compiler/config.py
@@ -176,6 +176,9 @@ class MetricsType(Flag):
     # been performed.
     OptimizedInstructionCount = auto()
 
+    # Returns raw instructions sent to the QPU.
+    OptimizedInstructions = auto()
+
     # Set of basic metrics that should be returned at all times.
     Default = OptimizedCircuit | OptimizedInstructionCount
 

--- a/src/QAT/qat/purr/compiler/metrics.py
+++ b/src/QAT/qat/purr/compiler/metrics.py
@@ -41,6 +41,7 @@ class CompilationMetrics(metaclass=_FlagFieldValidation):
 
     optimized_circuit: Optional[str]
     optimized_instruction_count: Optional[int]
+    optimized_instructions: Optional[str]
 
     def __init__(self, enabled_metrics=None):
         self.enabled_metrics: Optional[MetricsType] = (

--- a/src/QAT/qat/purr/compiler/runtime.py
+++ b/src/QAT/qat/purr/compiler/runtime.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Oxford Quantum Circuits Ltd
-
+import os
 from typing import List, TypeVar, Union
 
 from qat.purr.compiler.builders import InstructionBuilder, QuantumInstructionBuilder
@@ -119,6 +119,10 @@ class QuantumRuntime(MetricsMixin):
         self.record_metric(
             MetricsType.OptimizedInstructionCount, opt_inst_count := len(instructions)
         )
+
+        if self.are_metrics_enabled(MetricsType.OptimizedInstructions):
+            self.record_metric(MetricsType.OptimizedInstructions, os.linesep.join([str(inst) for inst in instructions]))
+
         log.info(f"Optimized instruction count: {opt_inst_count}")
 
         return self.engine.execute(instructions, results_format)


### PR DESCRIPTION
Knowing the optimized instructions is useful for many reasons but massively bloats the result, so make it an optional metric.

At this point the term metric may not be as appropriate as it used to be.