### PR TITLE
Bugfix/ker/sequential qubit referencing

### DIFF
--- a/src/QAT/qat/purr/compiler/hardware_models.py
+++ b/src/QAT/qat/purr/compiler/hardware_models.py
@@ -125,7 +125,7 @@ class QuantumHardwareModel(HardwareModel, Calibratable):
 
         if id_ not in self.quantum_devices:
             raise ValueError(
-                f"Tried to retrieve a qubit ({str(id_)}) that dosen't exist."
+                f"Tried to retrieve a qubit ({str(id_)}) that doesn't exist."
             )
 
         found_qubit = self.quantum_devices.get(id_)

--- a/src/QAT/qat/purr/integrations/qasm.py
+++ b/src/QAT/qat/purr/integrations/qasm.py
@@ -232,26 +232,25 @@ class AbstractParser:
         builder.ECR(qubits[0], qubits[1])
 
     def _get_qreg_index_range(self, reg_length, context, builder):
-        next_free = (
-            max(
-                [-1]
-                + [
-                    qubit.index
-                    for qubit_reg in context.registers.quantum.values()
-                    for qubit in qubit_reg.qubits
-                ]
-            )
-            + 1
+        next_free = 0
+        available_indices = [qubit.index for qubit in builder.model.qubits]
+
+        max_used = (
+                max(
+                    [-1]
+                    + [
+                        qubit.index
+                        for qubit_reg in context.registers.quantum.values()
+                        for qubit in qubit_reg.qubits
+                    ]
+                )
         )
-        index_range = [next_free + val for val in range(reg_length)]
-        invalid_qubits = [
-            ind for ind in index_range if not builder.model.has_qubit(ind)
-        ]
-        if any(invalid_qubits):
+        if max_used > -1:
+           next_free = available_indices.index(max_used) + 1
+        index_range = available_indices[next_free:next_free + reg_length]
+        if len(index_range) < reg_length:
             raise ValueError(
-                "Attempted to allocate qubits at index(es) "
-                f"{', '.join(str(index) for index in invalid_qubits)} "
-                "which aren't available."
+                "Attempted to allocate more qubits than available."
             )
 
         return index_range
@@ -1162,10 +1161,9 @@ class Qasm3Parser(Interpreter, AbstractParser):
 
                 if isinstance(registers, QubitRegister):
                     reg_index = self.transform_to_value(node.children[1])
-                    return next(
-                        (val for val in registers.qubits if val.index == reg_index),
-                        None,
-                    )
+                    if len(qubits:= registers.qubits) > reg_index:
+                        return qubits[reg_index]
+                    return None
 
             if data == "additive_expression":
                 return self.transform_to_value(

--- a/src/QAT/qat/purr/integrations/qir.py
+++ b/src/QAT/qat/purr/integrations/qir.py
@@ -43,7 +43,7 @@ class QIRParser:
         self.result_variables = []
 
     def _get_qubit(self, id_: int):
-        return self.hardware.get_qubit(id_)
+        return self.hardware.qubits[id_]
 
     def ccx(self, control1, control2, target):
         self.builder.ccnot(

--- a/src/tests/test_qasm.py
+++ b/src/tests/test_qasm.py
@@ -72,6 +72,7 @@ from .qasm_utils import (
     get_test_file_path,
     parse_and_apply_optimiziations,
 )
+from .utils import get_jagged_echo_hardware, update_qubit_indices
 
 
 class TestQASM3:
@@ -411,6 +412,60 @@ class TestQASM3:
             optimizations=Qasm3Optimizations(),
         )
         assert execute_qasm(qasm_string, hardware=hardware, compiler_config=config)
+
+    @pytest.mark.parametrize(
+        "qasm_file",
+        [
+            "basic.qasm",
+            "ghz.qasm",
+        ],
+    )
+    def test_on_jagged_hardware(self, qasm_file):
+        hw = get_jagged_echo_hardware(8)
+        qasm_string = get_qasm3(qasm_file)
+        parser = Qasm3Parser()
+        result = parser.parse(get_builder(hw), qasm_string)
+        assert len(result.instructions) > 0
+
+    @pytest.mark.parametrize(
+        "qasm_file",
+        [
+            "named_defcal_arg.qasm",
+            "delay.qasm",
+            "redefine_defcal.qasm",
+            "lark_parsing_test.qasm",
+            "arb_waveform.qasm",
+            "tmp.qasm",
+            "cx_override_test.qasm",
+            "ecr_test.qasm",
+            "openpulse_tests/acquire.qasm",
+            "openpulse_tests/expr_list_defcal_different_arg.qasm",
+            "openpulse_tests/set_frequency.qasm",
+            "openpulse_tests/freq.qasm",
+            "openpulse_tests/constant_wf.qasm",
+            "openpulse_tests/detune_gate.qasm",
+            "openpulse_tests/zmap.qasm",
+            "openpulse_tests/expr_list_caldef_1.qasm",
+            "openpulse_tests/expr_list_caldef_2.qasm",
+            "openpulse_tests/expr_list_caldef_3.qasm",
+            "openpulse_tests/waveform_numerical_types.qasm",
+            "openpulse_tests/cross_ressonance.qasm",
+            "openpulse_tests/shift_phase.qasm",
+            "waveform_tests/waveform_test_scale.qasm",
+            "waveform_tests/internal_waveform_tests.qasm",
+            "waveform_tests/waveform_test_phase_shift.qasm",
+            "waveform_tests/waveform_test_sum.qasm",
+        ],
+    )
+    def test_dollar_on_jagged_hardware(self, qasm_file):
+        hw = get_jagged_echo_hardware(8)
+        parser = Qasm3Parser()
+        qasm_string = get_qasm3(qasm_file)
+        with pytest.raises(ValueError):
+            parser.parse(get_builder(hw), qasm_string)
+        qasm_string = update_qubit_indices(qasm_string, [q.index for q in hw.qubits])
+        result = parser.parse(get_builder(hw), qasm_string)
+        assert len(result.instructions) > 0
 
 
 class TestExecutionFrontend:
@@ -831,6 +886,30 @@ class TestParsing:
 
     def test_ecr_already_exists(self):
         Qasm2Parser().parse(get_builder(self.echo), get_qasm2("ecr_exists.qasm"))
+
+
+    @pytest.mark.parametrize(
+        "qasm_file",
+        [
+            "basic.qasm",
+            "basic_results_formats.qasm",
+            "basic_single_measures.qasm",
+            "ecr_exists.qasm",
+            "ecr.qasm",
+            "invalid_mid_circuit_measure.qasm",
+            "logic_example.qasm",
+            "more_basic.qasm",
+            "parallel_test.qasm",
+            "primitives.qasm",
+            "valid_custom_gate.qasm",
+        ],
+    )
+    def test_on_jagged_hardware(self, qasm_file):
+        hw = get_jagged_echo_hardware(8)
+        qasm_string = get_qasm2(qasm_file)
+        parser = Qasm2Parser()
+        result = parser.parse(get_builder(hw), qasm_string)
+        assert len(result.instructions) > 0
 
 
 class TestQatOptimization:

--- a/src/tests/test_qir.py
+++ b/src/tests/test_qir.py
@@ -13,6 +13,7 @@ from qat.purr.integrations.qir import QIRParser
 from qat.qat import execute, execute_qir
 
 from tests.qasm_utils import TestFileType, get_test_file_path
+from tests.utils import get_jagged_echo_hardware
 
 
 def _get_qir_path(file_name):
@@ -242,3 +243,25 @@ class TestQIR:
             _get_qir_path("out_of_order_measure.ll"), compiler_config=config
         )
         assert len(results) == 4
+
+    @pytest.mark.parametrize(
+        "qir_file",
+        [
+            "base_profile_ops.ll",
+            "basic_cudaq.ll",
+            "bell_psi_minus.ll",
+            "bell_psi_plus.ll",
+            "bell_theta_minus.ll",
+            "bell_theta_plus.ll",
+            "complicated.ll",
+            "generator-bell.ll",
+            "hello.bc",
+            "out_of_order_measure.ll",
+            "select.bc",
+        ],
+    )
+    def test_on_jagged_hardware(self, qir_file):
+        hw = get_jagged_echo_hardware(8)
+        parser = QIRParser(hw)
+        builder = parser.parse(_get_qir_path(qir_file))
+        assert len(builder.instructions) > 0

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
+import numpy as np
+import random
+import re
+from typing import List
+
+from qat.purr.backends.utilities import get_axis_map
+from qat.purr.compiler.devices import (
+    ChannelType,
+    PhysicalBaseband,
+    PhysicalChannel,
+    Qubit,
+    Resonator,
+)
+from qat.purr.compiler.emitter import QatFile
+from qat.purr.compiler.execution import QuantumExecutionEngine, SweepIterator
+from qat.purr.compiler.hardware_models import QuantumHardwareModel
+from qat.purr.compiler.instructions import AcquireMode, PostProcessing
+
+
+def apply_setup_to_hardware(hw, qubit_indices: list):
+    """Apply the default echo hardware setup to the passed-in hardware."""
+    qubit_devices = []
+    resonator_devices = []
+    channel_index = 1
+    for primary_index in qubit_indices:
+        bb1 = PhysicalBaseband(f"LO{channel_index}", 5.5e9)
+        bb2 = PhysicalBaseband(f"LO{channel_index + 1}", 8.5e9)
+        hw.add_physical_baseband(bb1, bb2)
+
+        ch1 = PhysicalChannel(f"CH{channel_index}", 1.0e-9, bb1, 1)
+        ch2 = PhysicalChannel(
+            f"CH{channel_index + 1}", 1.0e-9, bb2, 1, acquire_allowed=True
+        )
+        hw.add_physical_channel(ch1, ch2)
+
+        resonator = Resonator(f"R{primary_index}", ch2)
+        resonator.create_pulse_channel(ChannelType.measure, frequency=8.5e9)
+        resonator.create_pulse_channel(ChannelType.acquire, frequency=8.5e9)
+
+        # As our main system is a ring architecture we just attach every qubit in the
+        # ring to the one on either side.
+        # 2 has a connection to 1 and 3. This number wraps around, so we also have
+        # 10-0-1 linkages.
+        qubit = Qubit(primary_index, resonator, ch1)
+        qubit.create_pulse_channel(ChannelType.drive, frequency=5.5e9)
+
+        qubit_devices.append(qubit)
+        resonator_devices.append(resonator)
+        channel_index = channel_index + 2
+
+    # TODO: For backwards compatability cross resonance pulse channels are fully
+    #   connected but coupled qubits are only in a ring architecture. I think it would be
+    #   more approriate for cross resonace channels to also be a ring architecture but
+    #   that can be done in a later PR.
+    def _cross_channels(q1, q2):
+        """Create cross resonance channels for q2 on q1."""
+        try:
+            q1.create_pulse_channel(
+                auxiliary_devices=[q2],
+                channel_type=ChannelType.cross_resonance,
+                frequency=5.5e9,
+                scale=50,
+            )
+            q1.create_pulse_channel(
+                auxiliary_devices=[q2],
+                channel_type=ChannelType.cross_resonance_cancellation,
+                frequency=5.5e9,
+                scale=0.0,
+            )
+        except KeyError as e:
+            pass
+    def _couple_qubits(q1, q2):
+        def _directional_couple_qubits(q1, q2):
+            if q2 in q1.coupled_qubits:
+                return
+            _cross_channels(q1, q2)
+            q1.add_coupled_qubit(q2)
+        _directional_couple_qubits(q1, q2)
+        _directional_couple_qubits(q2, q1)
+
+    for i, qubit in enumerate(qubit_devices):
+        for other_qubit in qubit_devices:
+            if qubit != other_qubit:
+                _cross_channels(qubit, other_qubit)
+        other_qubit = qubit_devices[(i + 1) % len(qubit_indices)]
+        _couple_qubits(qubit, other_qubit)
+
+    hw.add_quantum_device(*qubit_devices, *resonator_devices)
+    hw.is_calibrated = True
+    return hw
+
+
+def get_jagged_echo_hardware(qubit_count: int=4, qubit_indices: List[int]=[]) -> "QuantumHardwareModel":
+    model = QuantumHardwareModel()
+    if len(qubit_indices) == 0:
+        qubit_indices = random.sample(range(1, qubit_count+5), qubit_count)
+    qubit_indices.sort()
+    return apply_setup_to_hardware(model, qubit_indices)
+
+
+def update_qubit_indices(program: str, qubit_indices: List[int]) -> str:
+    """Adjust the physical qubit references in the program to use ones from qubit_indices."""
+    patterns = [r'(\$)(?P<dollar_index>\d+)',
+                r'(q)(?P<control>\d+)(_q)(?P<target>\d+)(_cross_resonance)',
+                r'(q|r)(?P<index>\d+)(_drive|_acquire|_measure)']
+    refs = []
+    for pattern in patterns:
+        refs.extend(list(re.finditer(pattern, program)))
+    refs.sort(key = lambda r: r.start())
+    new_program = ""
+    old_end = 0
+    for ref in refs:
+        keys = ref.groupdict().keys()
+        if "dollar_index" in keys:
+            new_program = (new_program + program[old_end:ref.start()] + ref.group(1)
+                           + str(qubit_indices[int(ref.group('dollar_index'))]))
+            old_end = ref.end()
+        elif ("control" and "target") in keys:
+            new_program = (new_program + program[old_end:ref.start()] + ref.group(1)
+                           + str(qubit_indices[int(ref.group('control'))]) +
+                           ref.group(3) + str(qubit_indices[int(ref.group('target'))]) +
+                          ref.group(5))
+            old_end = ref.end()
+        elif "index" in keys:
+            new_program = (new_program + program[old_end:ref.start()] + ref.group(1)
+                           + str(qubit_indices[int(ref.group('index'))]) +
+                           ref.group(3))
+            old_end = ref.end()
+
+    new_program += program[old_end:]
+    return new_program


### PR DESCRIPTION
Adjusting the way qubits references are handled in QASM and QIR integration to allow parsing and execution on hardware with jagged physical qubit indexing.