### PR TITLE
Highly temporary fix of pickle recursion error, not to be included in develop

### DIFF
--- a/src/QAT/qat/purr/compiler/devices.py
+++ b/src/QAT/qat/purr/compiler/devices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from enum import Enum, auto
 from typing import Dict, List, Optional, Set, TypeVar, Union
 
@@ -12,6 +13,10 @@ import numpy as np
 from jsonpickle import Pickler, Unpickler
 from jsonpickle.util import is_picklable
 from qat.purr.utils.logger import get_default_logger
+
+# TODO: Remove the setting of the recursion limit as soon as the pickling of hardware is
+# not blocked by the default limit.
+sys.setrecursionlimit(2000)
 
 log = get_default_logger()
 jsonpickle_numpy.register_handlers()

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -105,8 +105,9 @@ class TestCalibrationSavingAndLoading:
         assert os.path.exists(saved_path)
         assert original_calibration == echo.get_calibration()
 
-    def test_load_hardware_definition(self):
-        echo = get_default_echo_hardware()
+    @pytest.mark.parametrize("qubit_count", [4, 8, 35])
+    def test_load_hardware_definition(self, qubit_count):
+        echo = get_default_echo_hardware(qubit_count)
         original_calibration = echo.get_calibration()
         empty_hw = Calibratable.load_calibration(original_calibration)
 

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 import os
-import unittest
+import pytest
 
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.compiler.devices import Calibratable
@@ -55,14 +55,14 @@ class TestCalibrations:
         assert twobit.is_calibrated
 
 
-class CalibrationSavingAndLoadingTests(unittest.TestCase):
-    def setUp(self) -> None:
+class TestCalibrationSavingAndLoading:
+    def setup_method(self, method) -> None:
         self.calibration_filename = (
-            f"{self._testMethodName}_"
+            f"{method.__name__}_"
             f"{get_default_echo_hardware().__class__.__name__}.calibration.json"
         )
 
-    def tearDown(self) -> None:
+    def teardown_method(self, method) -> None:
         if os.path.exists(self.calibration_filename):
             os.remove(self.calibration_filename)
 
@@ -75,10 +75,9 @@ class CalibrationSavingAndLoadingTests(unittest.TestCase):
         for key, value in copied_echo.pulse_channels.items():
             channel_key = key[:3]
             original_channel = copied_echo.physical_channels[channel_key]
-            self.assertEqual(
-                id(value.physical_channel),
-                id(original_channel),
-                "Copied references are different objects.",
+            assert (
+                id(value.physical_channel) == id(original_channel),
+                "Copied references are different objects."
             )
 
         assert len(echo.basebands) == len(copied_echo.basebands)


### PR DESCRIPTION
This is a HIGHLY TEMPORARY fix for the Recursion Error that occurs when trying to pickle a larger hardware model. The reason for this is a less than ideal data structure that results in too many recursions for the default Python settings. This issue does not exist in develop and the fix should not be included when we move to that version.