### PR TITLE
Restore original copyright year.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright 2024 © Oxford Quantum Circuits Ltd
+Copyright 2023 © Oxford Quantum Circuits Ltd
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/src/QAT/qat/core.py
+++ b/src/QAT/qat/core.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from typing import Union
 

--- a/src/QAT/qat/purr/backends/calibrations/remote.py
+++ b/src/QAT/qat/purr/backends/calibrations/remote.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from typing import Dict, Union
 

--- a/src/QAT/qat/purr/backends/echo.py
+++ b/src/QAT/qat/purr/backends/echo.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from enum import Enum, auto
 from typing import List, Optional, Tuple, Union

--- a/src/QAT/qat/purr/backends/live.py
+++ b/src/QAT/qat/purr/backends/live.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from typing import Dict, List
 

--- a/src/QAT/qat/purr/backends/live_devices.py
+++ b/src/QAT/qat/purr/backends/live_devices.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from abc import abstractmethod
 from typing import Dict, Union

--- a/src/QAT/qat/purr/backends/qasm_sim.py
+++ b/src/QAT/qat/purr/backends/qasm_sim.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from typing import List, Union
 

--- a/src/QAT/qat/purr/backends/realtime_chip_simulator.py
+++ b/src/QAT/qat/purr/backends/realtime_chip_simulator.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from dataclasses import dataclass, field
 from enum import Enum, auto

--- a/src/QAT/qat/purr/backends/utilities.py
+++ b/src/QAT/qat/purr/backends/utilities.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from dataclasses import dataclass
 from functools import wraps

--- a/src/QAT/qat/purr/backends/verification.py
+++ b/src/QAT/qat/purr/backends/verification.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from abc import ABC, abstractmethod
 from typing import List, Optional

--- a/src/QAT/qat/purr/compiler/builders.py
+++ b/src/QAT/qat/purr/compiler/builders.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import itertools
 import math

--- a/src/QAT/qat/purr/compiler/caches.py
+++ b/src/QAT/qat/purr/compiler/caches.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import os
 import shutil

--- a/src/QAT/qat/purr/compiler/config.py
+++ b/src/QAT/qat/purr/compiler/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from __future__ import annotations
 

--- a/src/QAT/qat/purr/compiler/devices.py
+++ b/src/QAT/qat/purr/compiler/devices.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from __future__ import annotations
 

--- a/src/QAT/qat/purr/compiler/emitter.py
+++ b/src/QAT/qat/purr/compiler/emitter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from __future__ import annotations
 

--- a/src/QAT/qat/purr/compiler/execution.py
+++ b/src/QAT/qat/purr/compiler/execution.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import abc
 from decimal import ROUND_DOWN, Decimal

--- a/src/QAT/qat/purr/compiler/frontends.py
+++ b/src/QAT/qat/purr/compiler/frontends.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import abc
 import os

--- a/src/QAT/qat/purr/compiler/hardware_models.py
+++ b/src/QAT/qat/purr/compiler/hardware_models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from __future__ import annotations
 

--- a/src/QAT/qat/purr/compiler/instructions.py
+++ b/src/QAT/qat/purr/compiler/instructions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from __future__ import annotations
 

--- a/src/QAT/qat/purr/compiler/metrics.py
+++ b/src/QAT/qat/purr/compiler/metrics.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from typing import List, Optional
 

--- a/src/QAT/qat/purr/compiler/optimisers.py
+++ b/src/QAT/qat/purr/compiler/optimisers.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from qat.purr.compiler.config import (
     MetricsType,

--- a/src/QAT/qat/purr/compiler/runtime.py
+++ b/src/QAT/qat/purr/compiler/runtime.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from typing import List, TypeVar, Union
 

--- a/src/QAT/qat/purr/compiler/waveforms.py
+++ b/src/QAT/qat/purr/compiler/waveforms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from dataclasses import dataclass
 from typing import Dict

--- a/src/QAT/qat/purr/integrations/features.py
+++ b/src/QAT/qat/purr/integrations/features.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from dataclasses import dataclass
 from enum import Enum

--- a/src/QAT/qat/purr/integrations/qasm.py
+++ b/src/QAT/qat/purr/integrations/qasm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import abc
 import math

--- a/src/QAT/qat/purr/integrations/qir.py
+++ b/src/QAT/qat/purr/integrations/qir.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 
 def get_qir_executor(*args, **kwargs):

--- a/src/QAT/qat/purr/integrations/qiskit.py
+++ b/src/QAT/qat/purr/integrations/qiskit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import time
 import uuid

--- a/src/QAT/qat/purr/integrations/tket.py
+++ b/src/QAT/qat/purr/integrations/tket.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from numbers import Number
 from typing import List

--- a/src/QAT/qat/purr/utils/benchmarking.py
+++ b/src/QAT/qat/purr/utils/benchmarking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import qiskit.ignis.verification.randomized_benchmarking as rb
 from qat.purr.compiler.runtime import get_builder

--- a/src/QAT/qat/purr/utils/logger.py
+++ b/src/QAT/qat/purr/utils/logger.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import atexit
 import logging

--- a/src/QAT/qat/purr/utils/logging_utils.py
+++ b/src/QAT/qat/purr/utils/logging_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import sys
 import time

--- a/src/QAT/qat/purr/utils/serializer.py
+++ b/src/QAT/qat/purr/utils/serializer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import json
 import re

--- a/src/tests/qasm_utils.py
+++ b/src/tests/qasm_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from enum import Enum, auto
 from os.path import abspath, dirname, join

--- a/src/tests/test_benchmarking.py
+++ b/src/tests/test_benchmarking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.compiler.runtime import execute_instructions

--- a/src/tests/test_cache.py
+++ b/src/tests/test_cache.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import os
 import unittest

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import os
 import unittest

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from os.path import abspath, dirname, join
 from sys import __loader__

--- a/src/tests/test_instructions.py
+++ b/src/tests/test_instructions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import numpy as np
 import pytest

--- a/src/tests/test_live.py
+++ b/src/tests/test_live.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import unittest
 

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import datetime
 import inspect

--- a/src/tests/test_qasm.py
+++ b/src/tests/test_qasm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from os import listdir
 from os.path import dirname, isfile, join

--- a/src/tests/test_qir.py
+++ b/src/tests/test_qir.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from os.path import abspath, dirname, join
 from unittest import mock

--- a/src/tests/test_quantum_backend.py
+++ b/src/tests/test_quantum_backend.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import tempfile
 from os.path import dirname, join

--- a/src/tests/test_rtcs_backend.py
+++ b/src/tests/test_rtcs_backend.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import numpy as np
 import pytest

--- a/src/tests/test_serializer.py
+++ b/src/tests/test_serializer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from dataclasses import asdict, dataclass, is_dataclass
 

--- a/src/tests/test_tket.py
+++ b/src/tests/test_tket.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.compiler.config import Qasm2Optimizations, TketOptimizations

--- a/src/tests/test_utilities.py
+++ b/src/tests/test_utilities.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import numpy as np
 import pytest

--- a/src/tests/test_verification.py
+++ b/src/tests/test_verification.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Oxford Quantum Circuits Ltd
+# Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 from qat.purr.backends.verification import get_verification_model, Lucy, QPUVersion
 from qat import execute


### PR DESCRIPTION
As per long discussions last year, the first year that copyright is applied should always be kept in the statement. Reverting the change to keep this accurate.