### PR TITLE
Bugfix/ker/minor fixes

### DIFF
--- a/src/QAT/qat/core.py
+++ b/src/QAT/qat/core.py
@@ -53,7 +53,7 @@ def execute_with_metrics(
         )
         return results, metrics.as_dict()
 
-    raise ValueError(f"No compiler support for inputs of type {str(type(incoming))}")
+    raise TypeError(f"No compiler support for inputs of type {str(type(incoming))}")
 
 
 def execute_qir(qir_file: str, hardware=None, compiler_config: CompilerConfig=None):

--- a/src/QAT/qat/purr/backends/live.py
+++ b/src/QAT/qat/purr/backends/live.py
@@ -197,7 +197,8 @@ class LiveDeviceEngine(QuantumExecutionEngine):
     def startup(self):
         for instrument in self.model.instruments.values():
             instrument.connect()
-        self.model.control_hardware.connect()
+        if self.model.control_hardware is not None:
+            self.model.control_hardware.connect()
         for baseband in self.model.basebands.values():
             if isinstance(baseband, LivePhysicalBaseband):
                 baseband.connect_to_instrument()
@@ -209,7 +210,8 @@ class LiveDeviceEngine(QuantumExecutionEngine):
     def shutdown(self):
         for instrument in self.model.instruments.values():
             instrument.close()
-        self.model.control_hardware.close()
+        if self.model.control_hardware is not None:
+            self.model.control_hardware.close()
 
     def process_reset(self, position):
         raise NotImplementedError(

--- a/src/QAT/qat/purr/backends/live_devices.py
+++ b/src/QAT/qat/purr/backends/live_devices.py
@@ -74,10 +74,11 @@ class ControlHardwareChannel(PhysicalChannel):
     derived) object should contain hardware specific information.
     """
 
-    def __init__(self, id_, hardware_id, dcbiaschannel_pair, *args, **kwargs):
+    def __init__(self, id_, hardware_id, dcbiaschannel_pair, *args, switch_ch=None, **kwargs):
         super().__init__(id_, *args, **kwargs)
         self.hardware_id = hardware_id
         self.dcbiaschannel_pair: Dict[str, DCBiasChannel] = dcbiaschannel_pair
+        self.switch_ch: str = switch_ch
 
 
 class ControlHardware(Instrument):

--- a/src/QAT/qat/purr/compiler/builders.py
+++ b/src/QAT/qat/purr/compiler/builders.py
@@ -6,7 +6,6 @@ import math
 from enum import Enum, auto
 from typing import List, Set, Union
 
-import numpy
 import numpy as np
 from qat.purr.compiler.config import InlineResultsProcessing
 from qat.purr.compiler.devices import ChannelType, PulseChannel, QuantumComponent, Qubit
@@ -279,22 +278,22 @@ class InstructionBuilder:
         raise ValueError("Not available on this hardware model.")
 
     def SX(self, target):
-        return self.X(target, numpy.pi / 2)
+        return self.X(target, np.pi / 2)
 
     def SXdg(self, target):
-        return self.X(target, -(numpy.pi / 2))
+        return self.X(target, -(np.pi / 2))
 
     def S(self, target):
-        return self.Z(target, numpy.pi / 2)
+        return self.Z(target, np.pi / 2)
 
     def Sdg(self, target):
-        return self.Z(target, -(numpy.pi / 2))
+        return self.Z(target, -(np.pi / 2))
 
     def T(self, target):
-        return self.Z(target, numpy.pi / 4)
+        return self.Z(target, np.pi / 4)
 
     def Tdg(self, target):
-        return self.Z(target, -(numpy.pi / 4))
+        return self.Z(target, -(np.pi / 4))
 
     def cR(
         self,

--- a/src/QAT/qat/purr/compiler/devices.py
+++ b/src/QAT/qat/purr/compiler/devices.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from enum import Enum, auto
 from typing import Dict, List, Optional, Set, TypeVar, Union
 
@@ -13,6 +14,10 @@ import numpy as np
 from jsonpickle import Pickler, Unpickler
 from jsonpickle.util import is_picklable
 from qat.purr.utils.logger import get_default_logger
+
+# TODO: Remove the setting of the recursion limit as soon as the pickling of hardware is
+# not blocked by the default limit.
+sys.setrecursionlimit(3000)
 
 log = get_default_logger()
 jsonpickle_numpy.register_handlers()

--- a/src/QAT/qat/purr/compiler/execution.py
+++ b/src/QAT/qat/purr/compiler/execution.py
@@ -369,11 +369,13 @@ class QuantumExecutionEngine(InstructionExecutionEngine):
 
                 # Assign shortened repeat for this execution then reset it.
                 qat_file.repeat.repeat_count = batch_count
-                dinjectors.inject()
-                batch_results = self._execute_on_hardware(switerator, qat_file)
-                switerator.revert(qat_file.instructions)
-                dinjectors.revert()
-                qat_file.repeat.repeat_count = repeat_count
+                try:
+                    dinjectors.inject()
+                    batch_results = self._execute_on_hardware(switerator, qat_file)
+                finally:
+                    switerator.revert(qat_file.instructions)
+                    dinjectors.revert()
+                    qat_file.repeat.repeat_count = repeat_count
 
                 if not any(results):
                     results = batch_results

--- a/src/QAT/qat/purr/compiler/execution.py
+++ b/src/QAT/qat/purr/compiler/execution.py
@@ -250,7 +250,7 @@ class QuantumExecutionEngine(InstructionExecutionEngine):
         accum_phaseshifts: Dict[PulseChannel, PhaseShift] = {}
         optimized_instructions: List[Instruction] = []
         for instruction in instructions:
-            if isinstance(instruction, PhaseShift):
+            if isinstance(instruction, PhaseShift) and isinstance(instruction.phase, Number):
                 if accum_phaseshift := accum_phaseshifts.get(instruction.channel, None):
                     accum_phaseshift.phase += instruction.phase
                 else:

--- a/src/QAT/qat/purr/compiler/hardware_models.py
+++ b/src/QAT/qat/purr/compiler/hardware_models.py
@@ -148,7 +148,7 @@ class QuantumHardwareModel(HardwareModel, Calibratable):
 
         if id_ not in self.quantum_devices:
             raise ValueError(
-                f"Tried to retrieve a qubit ({str(id_)}) that dosen't exist."
+                f"Tried to retrieve a qubit ({str(id_)}) that doesn't exist."
             )
 
         found_qubit = self.quantum_devices.get(id_)

--- a/src/QAT/qat/purr/integrations/qasm.py
+++ b/src/QAT/qat/purr/integrations/qasm.py
@@ -1303,7 +1303,7 @@ class Qasm3Parser(Interpreter, AbstractQASMParser):
         name = self.transform_to_value(tree.children[1])
         args = self.transform_to_value(tree.children[4])
         port = args[0]
-        frequency = args[1]
+        frequency = self._get_frequency(args[1][0]) if isinstance(args[1], list) else args[1]
         phase = 0.0 if len(args) <= 2 else args[2]
 
         if isinstance(port, PulseChannel):

--- a/src/tests/files/qasm/qasm3/complex_gates_test.qasm
+++ b/src/tests/files/qasm/qasm3/complex_gates_test.qasm
@@ -25,8 +25,8 @@ defcal sx $1 {
 }
 
 defcal cx $1, $0 {
-   waveform CR90p = gaussian_square(1e-6, 560dt, 240dt, 40dt);
-   waveform CR90m = gaussian_square(1e-6, 560dt, 240dt, 40dt);
+   waveform CR90p = square(1e-6, 560dt);
+   waveform CR90m = gaussian(1e-6, 560dt, 240dt);
 
    rz(pi/2) $0; rz(-pi/2) $1;
    sx $0; sx $1;

--- a/src/tests/files/qasm/qasm3/openpulse_tests/freq.qasm
+++ b/src/tests/files/qasm/qasm3/openpulse_tests/freq.qasm
@@ -1,0 +1,18 @@
+OPENQASM 3;
+defcalgrammar "openpulse";
+
+cal {
+   extern port channel_1;
+   extern port channel_2;
+   extern frame q0_drive;
+}
+
+defcal cross_resonance $0, $1 {
+    waveform wf1 = sine(1., 1024dt, 128dt, 32dt);
+    waveform wf2 = sine(0.1, 1024dt, 128dt, 32dt);
+    frame temp_frame = newframe(channel_2, q0_drive.frequency, 0);
+    frame temp_frame2 = newframe(channel_2, get_frequency(q0_drive), 0);
+    play(temp_frame2, wf1);
+    play(temp_frame, wf2);
+}
+cross_resonance $0, $1;

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import os
-import unittest
+import pytest
 
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.compiler.devices import Calibratable
@@ -55,14 +55,14 @@ class TestCalibrations:
         assert twobit.is_calibrated
 
 
-class CalibrationSavingAndLoadingTests(unittest.TestCase):
-    def setUp(self) -> None:
+class TestCalibrationSavingAndLoading:
+    def setup_method(self, method) -> None:
         self.calibration_filename = (
-            f"{self._testMethodName}_"
+            f"{method.__name__}_"
             f"{get_default_echo_hardware().__class__.__name__}.calibration.json"
         )
 
-    def tearDown(self) -> None:
+    def teardown_method(self, method) -> None:
         if os.path.exists(self.calibration_filename):
             os.remove(self.calibration_filename)
 
@@ -75,9 +75,8 @@ class CalibrationSavingAndLoadingTests(unittest.TestCase):
         for key, value in copied_echo.pulse_channels.items():
             channel_key = key[:3]
             original_channel = copied_echo.physical_channels[channel_key]
-            self.assertEqual(
-                id(value.physical_channel),
-                id(original_channel),
+            assert (
+                id(value.physical_channel) == id(original_channel),
                 "Copied references are different objects.",
             )
 

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -88,8 +88,9 @@ class TestCalibrationSavingAndLoading:
             copied_echo.qubit_direction_couplings
         )
 
-    def test_load_hardware_definition(self):
-        echo = get_default_echo_hardware()
+    @pytest.mark.parametrize("qubit_count", [4, 8, 35])
+    def test_load_hardware_definition(self, qubit_count):
+        echo = get_default_echo_hardware(qubit_count)
         original_calibration = echo.get_calibration()
         empty_hw = Calibratable.load_calibration(original_calibration)
 

--- a/src/tests/test_qasm.py
+++ b/src/tests/test_qasm.py
@@ -113,6 +113,10 @@ class TestQASM3:
         results = execute_qasm(get_qasm3("openpulse_tests/zmap.qasm"), hw)
         assert not isinstance(results, dict)
 
+    def test_frequency(self):
+        hw = get_default_echo_hardware(8)
+        execute_qasm(get_qasm3("openpulse_tests/freq.qasm"), hw)
+
     @pytest.mark.parametrize(
         "arg_count",
         [1, 2, 3],  # 2 includes a generic qubit def, should be separate test

--- a/src/tests/test_qasm.py
+++ b/src/tests/test_qasm.py
@@ -165,7 +165,6 @@ class TestQASM3:
 
         assert len(v3_instructions.instructions) == len(v2_instructions.instructions)
 
-    @pytest.mark.skip(reason="Need to be able to parse 'dt' correctly.")
     def test_complex_gates(self):
         hw = get_default_echo_hardware(8)
         execute_qasm(get_qasm3("complex_gates_test.qasm"), hw)

--- a/src/tests/test_qasm.py
+++ b/src/tests/test_qasm.py
@@ -480,6 +480,23 @@ class TestQASM3:
         result = parser.parse(get_builder(hw), qasm_string)
         assert len(result.instructions) > 0
 
+    def test_execute_different_qat_input_types(self):
+        hw = get_default_echo_hardware(5)
+        qubit = hw.get_qubit(0)
+        phase_shift_1 = 0.2
+        phase_shift_2 = 0.1
+        builder = (
+            get_builder(hw)
+            .phase_shift(qubit, phase_shift_1)
+            .X(qubit, np.pi / 2.0)
+            .phase_shift(qubit, phase_shift_2)
+            .X(qubit, np.pi / 2.0)
+            .measure_mean_z(qubit)
+        )
+
+        with pytest.raises(TypeError):
+            execute_qasm(qat_input=builder.instructions, hardware=hw)
+
 
 class TestExecutionFrontend:
     def test_invalid_paths(self):
@@ -852,6 +869,23 @@ class TestExecutionFrontend:
         parser = Qasm2Parser()
         result = parser.parse(get_builder(hw), qasm_string)
         assert len(result.instructions) > 0
+
+    def test_execute_different_qat_input_types(self):
+        hw = get_default_echo_hardware(5)
+        qubit = hw.get_qubit(0)
+        phase_shift_1 = 0.2
+        phase_shift_2 = 0.1
+        builder = (
+            get_builder(hw)
+            .phase_shift(qubit, phase_shift_1)
+            .X(qubit, np.pi / 2.0)
+            .phase_shift(qubit, phase_shift_2)
+            .X(qubit, np.pi / 2.0)
+            .measure_mean_z(qubit)
+        )
+
+        with pytest.raises(TypeError):
+            execute_qasm(qat_input=builder.instructions, hardware=hw)
 
 
 class TestParsing:

--- a/src/tests/test_qir.py
+++ b/src/tests/test_qir.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
 import base64
+import numpy as np
 from os.path import abspath, dirname, join
 from unittest import mock
 
@@ -261,3 +262,20 @@ class TestQIR:
         parser = QIRParser(hw)
         builder = parser.parse(_get_qir_path(qir_file))
         assert len(builder.instructions) > 0
+
+    def test_execute_different_qat_input_types(self):
+        hw = get_default_echo_hardware(5)
+        qubit = hw.get_qubit(0)
+        phase_shift_1 = 0.2
+        phase_shift_2 = 0.1
+        builder = (
+            hw.create_builder()
+            .phase_shift(qubit, phase_shift_1)
+            .X(qubit, np.pi / 2.0)
+            .phase_shift(qubit, phase_shift_2)
+            .X(qubit, np.pi / 2.0)
+            .measure_mean_z(qubit)
+        )
+
+        with pytest.raises(TypeError):
+            execute_qir(qat_input=builder.instructions)

--- a/src/tests/test_quantum_backend.py
+++ b/src/tests/test_quantum_backend.py
@@ -31,7 +31,7 @@ from qat.purr.compiler.devices import (
 )
 from qat.purr.compiler.emitter import QatFile
 from qat.purr.compiler.hardware_models import QuantumHardwareModel
-from qat.purr.compiler.instructions import SweepValue, Variable
+from qat.purr.compiler.instructions import PhaseShift, SweepValue, Variable
 from qat.purr.compiler.runtime import QuantumRuntime, execute_instructions, get_builder
 from qat.purr.integrations.qasm import Qasm2Parser
 from scipy import fftpack
@@ -487,3 +487,61 @@ class TestBaseQuantum:
         assert len(qubit2_buffer) > 0
         assert np.isclose([abs(val) for val in qubit1_buffer], 2).all()
         assert np.isclose([abs(val) for val in qubit2_buffer], 1).all()
+
+    def test_phase_shift_optimisation_squashes_down_adjacent_phase_shifts(self):
+        hw = get_test_model()
+        qubit = hw.get_qubit(0)
+        phase_shift_1 = 0.2
+        phase_shift_2 = 0.1
+        builder = (
+            get_builder(hw)
+            .X(qubit, np.pi / 2.0)
+            .phase_shift(qubit, phase_shift_1)
+            .phase_shift(qubit, phase_shift_2)
+            .X(qubit, np.pi / 2.0).measure_mean_z(qubit)
+        )
+        engine = get_test_execution_engine(hw)
+        optimized_instructions = engine.optimize(builder.instructions)
+        phase_shift_list = [instr for instr in optimized_instructions if isinstance(instr, PhaseShift)]
+        assert len(phase_shift_list) == 1
+        assert phase_shift_list[0].phase == phase_shift_1 + phase_shift_2
+
+    def test_phase_shift_optimisation_does_not_squash_down_non_adjacent_phase_shifts(self):
+        hw = get_test_model()
+        qubit = hw.get_qubit(0)
+        phase_shift_1 = 0.2
+        phase_shift_2 = 0.1
+        builder = (
+            get_builder(hw)
+            .phase_shift(qubit, phase_shift_1)
+            .X(qubit, np.pi / 2.0)
+            .phase_shift(qubit, phase_shift_2)
+            .X(qubit, np.pi / 2.0)
+            .measure_mean_z(qubit)
+        )
+        engine = get_test_execution_engine(hw)
+        optimized_instructions = engine.optimize(builder.instructions)
+        phase_shift_list = [instr for instr in optimized_instructions if isinstance(instr, PhaseShift)]
+        assert len(phase_shift_list) == 2
+        assert phase_shift_list[0].phase == phase_shift_1
+        assert phase_shift_list[1].phase == phase_shift_2
+
+    def test_phase_shift_optimisation_skips_sweep_variables(self):
+        hw = get_test_model()
+        qubit = hw.get_qubit(0)
+        phase_shift_fixed = 0.2
+        phase_shift_sweep = np.linspace(0.0, 1.0, 5)
+        builder = (
+            get_builder(hw)
+            .sweep(SweepValue("p", phase_shift_sweep))
+            .X(qubit, np.pi / 2.0)
+            .phase_shift(qubit, Variable("p"))
+            .phase_shift(qubit, phase_shift_fixed)
+            .X(qubit, np.pi / 2.0).measure_mean_z(qubit)
+        )
+        engine = get_test_execution_engine(hw)
+        optimized_instructions = engine.optimize(builder.instructions)
+        phase_shift_list = [instr for instr in optimized_instructions if isinstance(instr, PhaseShift)]
+        assert len(phase_shift_list) == 2
+        assert phase_shift_list[1].phase == phase_shift_fixed
+        assert isinstance(phase_shift_list[0].phase, Variable)


### PR DESCRIPTION
Collated minor fixes ported from main:
- Test raise TypeError when executing unsupported type.
- Enable skipped complex gate test.
- Ensure sweep iterators are always reverted.
- Extend test_load_hardware_definition to different qubit_counts, and temp fix reursion issue.
- Convert test_calibration.py to pytest format.
- Fix minor typo.
- Improved QuantumInstruction add_channel functionality.
- Removed duplicate numpy import.
- Allowing the hardware to work without a control hardware.
- Adding hardcoded delay to qubit drives and counting two clock cycles per instruction for the sequencer.
- Wh/switch hive fix.
- Fix frequency frame attribute access.