### PR TITLE
Bugfix/ker/measure instruction tests develop

### DIFF
--- a/src/QAT/qat/purr/backends/utilities.py
+++ b/src/QAT/qat/purr/backends/utilities.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 from functools import wraps
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -440,8 +440,8 @@ def software_post_process_linear_map_complex_to_real(
 
 
 def software_post_process_discriminate(
-    args, raw: List[np.ndarray], axes: Dict[ProcessAxis, int]
+    args, raw: Union[np.ndarray, List[np.ndarray]], axes: Dict[ProcessAxis, int]
 ):
-    z_vals = raw[0]
+    z_vals = raw[0] if isinstance(raw, list) else raw
     discr = args[0]
     return np.array([-1 if z_val < discr else 1 for z_val in z_vals]), axes

--- a/src/tests/test_instructions.py
+++ b/src/tests/test_instructions.py
@@ -84,8 +84,18 @@ class TestInstruction:
 
 
 class TestInstructionExecution:
-    @pytest.mark.skip("Needs fixing post processing and down-conversion issues.")
-    def test_measure_instructions(hw):
+    @pytest.mark.parametrize(
+        "measure_instruction",
+        [
+            "measure_mean_z",
+            "measure_mean_signal",
+            "measure_single_shot_z",
+            "measure_scope_mode",
+            "measure_single_shot_binned",
+            "measure_single_shot_signal",
+        ],
+    )
+    def test_measure_instructions(self, measure_instruction):
         hw = get_default_echo_hardware(3)
         qubit = hw.get_qubit(0)
         phase_shift_1 = 0.2
@@ -96,15 +106,9 @@ class TestInstructionExecution:
             .X(qubit, np.pi / 2.0)
             .phase_shift(qubit, phase_shift_2)
             .X(qubit, np.pi / 2.0)
-            .measure_mean_z(qubit)  # triggers a KeyError
-            .measure_mean_signal(qubit)
-            .measure_single_shot_z(qubit)
-            .measure_scope_mode(qubit)
-            .measure_single_shot_binned(qubit)
-            .measure_single_shot_signal(qubit)
         )
-        engine = EchoEngine(hw)
-        results = engine.execute(builder.instructions)
+        getattr(builder, measure_instruction)(qubit)
+        results = execute_instructions(hw, builder)
         assert results is not None
 
     def check_size(self, results, expected_shape):

--- a/src/tests/test_instructions.py
+++ b/src/tests/test_instructions.py
@@ -87,13 +87,14 @@ class TestInstructionExecution:
     @pytest.mark.parametrize(
         "measure_instruction",
         [
-            "measure_mean_z",
-            "measure_mean_signal",
-            "measure_single_shot_z",
-            "measure_scope_mode",
-            "measure_single_shot_binned",
-            "measure_single_shot_signal",
+            lambda b: b.measure_mean_z,
+            lambda b: b.measure_mean_signal,
+            lambda b: b.measure_single_shot_z,
+            lambda b: b.measure_scope_mode,
+            lambda b: b.measure_single_shot_binned,
+            lambda b: b.measure_single_shot_signal,
         ],
+        ids=lambda v: v.__code__.co_names[0],
     )
     def test_measure_instructions(self, measure_instruction):
         hw = get_default_echo_hardware(3)
@@ -107,7 +108,7 @@ class TestInstructionExecution:
             .phase_shift(qubit, phase_shift_2)
             .X(qubit, np.pi / 2.0)
         )
-        getattr(builder, measure_instruction)(qubit)
+        measure_instruction(builder)(qubit)
         results = execute_instructions(hw, builder)
         assert results is not None
 


### PR DESCRIPTION
Enabling previously skipped tests for measurement instructions and fixing the issue that required it to be skipped.