### PR TITLE
Fix infinite recursion when disconnecting Instruments.

### DIFF
--- a/src/QAT/qat/purr/backends/live_devices.py
+++ b/src/QAT/qat/purr/backends/live_devices.py
@@ -36,7 +36,9 @@ class Instrument(Calibratable):
         if self.driver is not None:
             try:
                 self.driver.close()
-                self.driver = None
+                # The current version of the drivers required the link to be removed for
+                # proper operation. Adjust this when it is no longer needed.
+                self._driver = None
                 self.is_connected = False
             except BaseException as e:
                 log.warning(


### PR DESCRIPTION
Simple change that stops infinite looping between `Instrument.disconnect()` and `Instrument.driver = None`.