### PR TITLE
Fixed qat-compiler-minimal readme formatting to allow releasing to PyPI.

### DIFF
--- a/partials/minimal/README.rst
+++ b/partials/minimal/README.rst
@@ -16,7 +16,8 @@ which are then transformed and delivered to an appropriate driver.
 
 For more information, please see the `main package <https://pypi.org/project/qat-compiler/>`_.
 
-For the official QAT documentation, please see `QAT <https://oqc-community.github.io/qat>`_.
+For the official QAT documentation, please see `QAT <https://oqc-community.github.io/qat>`__.
+
 |
 
 ----------------------
@@ -32,7 +33,7 @@ This minimal version of QAT can be installed from `PyPI <https://pypi.org/projec
 Building from Source
 ----------------------
 
-We do not distribute the minimal package source code as a separate entity. Please see the main `QAT <https://github.com/oqc-community/qat>`_ repository for source code.
+We do not distribute the minimal package source code as a separate entity. Please see the main `QAT <https://github.com/oqc-community/qat>`__ repository for source code.
 
 |
 


### PR DESCRIPTION
PyPI is unable to render the description when multiple links have the same "name". Adding an additional `_` at the end of the link command fixes this and unblock publishing to PyPI.