### PR TITLE
Fix plot pulse buffer example script

### DIFF
--- a/examples/plot_pulse_buffers.py
+++ b/examples/plot_pulse_buffers.py
@@ -38,7 +38,7 @@ class PhysicalBufferPlotEngine(EchoEngine):
         self.name = name
 
     def _execute_on_hardware(self, sweep_iterator: SweepIterator, package: QatFile):
-        position_map = self.target.create_duration_timeline(package)
+        position_map = self.target.create_duration_timeline(package.instructions)
         pulse_buffers = self.target.build_pulse_channel_buffers(
             position_map, do_upconvert=self.upconvert
         )


### PR DESCRIPTION
A fix for https://github.com/oqc-community/qat/issues/117. The method `PhysicalBufferPlotEngine._execute_on_hardware()` should call `QuantumExecutionEngine.create_duration_timeline()` with the instructions list and not qat_file.