### PR TITLE
Custom pulses now handled correctly in execution

### DIFF
--- a/src/QAT/qat/purr/compiler/execution.py
+++ b/src/QAT/qat/purr/compiler/execution.py
@@ -202,7 +202,7 @@ class QuantumExecutionEngine(InstructionExecutionEngine):
                     accum_phaseshifts[instruction.channel] = PhaseShift(
                         instruction.channel, instruction.phase
                     )
-            elif isinstance(instruction, Pulse):
+            elif isinstance(instruction, (Pulse, CustomPulse)):
                 quantum_targets = getattr(instruction, "quantum_targets", [])
                 if not isinstance(quantum_targets, List):
                     quantum_targets = [quantum_targets]
@@ -237,7 +237,7 @@ class QuantumExecutionEngine(InstructionExecutionEngine):
                     f"Cannot perform an acquire on the physical channel with id "
                     f"{inst.channel.physical_channel}"
                 )
-            if isinstance(inst, Pulse):
+            if isinstance(inst, (Pulse, CustomPulse)):
                 duration = inst.duration
                 if isinstance(duration, Number) and duration > MaxPulseLength:
                     raise ValueError(


### PR DESCRIPTION
Custom pulses were not accumulating phase correctly like regular pulses. This seems fine for 1q calibrations, but when experimenting with ECR gates comprised of custom pulses this breaks, resulting in any 2q calibrations involving ECR gates to fail as well as Randomized Benchmarking.