### PR TITLE
QBlox config and test improvements

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -27,6 +27,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
       - name: Bump version and push tag
         id: update
         run: |

--- a/src/QAT/qat/purr/backends/qblox/constants.py
+++ b/src/QAT/qat/purr/backends/qblox/constants.py
@@ -1,0 +1,63 @@
+class Constants:
+    IMMEDIATE_MAX_WAIT_TIME = pow(2, 16) - 4
+    """Max size of wait instruction immediates in Q1ASM programs. Max value allowed by
+    assembler is 2**16-1, but this is the largest that is a multiple of 4 ns."""
+    REGISTER_SIZE = pow(2, 32) - 1
+    """Size of registers in Q1ASM programs."""
+    NCO_PHASE_STEPS_PER_DEG = 1e9 / 360
+    """The number of steps per degree for NCO phase instructions arguments."""
+    NCO_FREQ_STEPS_PER_HZ = 4.0
+    """The number of steps per Hz for the NCO set_freq instruction."""
+    NCO_FREQ_LIMIT_STEPS = 2e9
+    """The maximum and minimum frequency expressed in steps for the NCO set_freq instruction.
+    For the minimum we multiply by -1."""
+    NUMBER_OF_SEQUENCERS_QCM = 6
+    """Number of sequencers supported by a QCM/QCM-RF in the latest firmware."""
+    NUMBER_OF_SEQUENCERS_QRM = 6
+    """Number of sequencers supported by a QRM/QRM-RF in the latest firmware."""
+    NUMBER_OF_REGISTERS: int = 64
+    """Number of registers available in the Qblox sequencers."""
+    MAX_SAMPLE_SIZE_SCOPE_ACQUISITIONS: int = 16384
+    """Maximal amount of scope trace acquisition datapoints returned."""
+    MAX_SAMPLE_SIZE_WAVEFORMS: int = 16384
+    """Maximal amount of samples in the waveforms to be uploaded to a sequencer."""
+    GRID_TIME = 4  # ns
+    """
+    Clock period of the sequencers. All time intervals used must be multiples of this value.
+    """
+    LOOP_UNROLL_THRESHOLD = 4
+    """
+    Size above which loops have tolerable overhead
+    """
+    MIN_QCM_OFFSET_V = -2.5
+    """
+    Minimum offset for QCM
+    """
+    MAX_QCM_OFFSET_V = 2.5
+    """
+    Maximum offset for QCM
+    """
+    MIN_QCM_RF_OFFSET_MV = -84
+    """
+    Minimum offset for QCM-RF
+    """
+    MAX_QCM_RF_OFFSET_MV = 73
+    """
+    Maximum offset for QCM-RF
+    """
+    MIN_QRM_OFFSET_V = -0.09
+    """
+    Minimum offset for QRM
+    """
+    MAX_QRM_OFFSET_V = 0.09
+    """
+    Maximum offset for QRM
+    """
+    MIN_QRM_RF_OFFSET_V = -0.09
+    """
+    Minimum offset for QRM-RF
+    """
+    MAX_QRM_RF_OFFSET_V = 0.09
+    """
+    Maximum offset for QRM-RF
+    """

--- a/src/QAT/qat/purr/backends/qblox/ir.py
+++ b/src/QAT/qat/purr/backends/qblox/ir.py
@@ -5,39 +5,6 @@ from typing import Any, Dict, List, Tuple, Union
 import numpy as np
 
 
-class Constants:
-    IMMEDIATE_MAX_WAIT_TIME = pow(2, 16) - 4
-    """Max size of wait instruction immediates in Q1ASM programs. Max value allowed by
-    assembler is 2**16-1, but this is the largest that is a multiple of 4 ns."""
-    REGISTER_SIZE = pow(2, 32) - 1
-    """Size of registers in Q1ASM programs."""
-    NCO_PHASE_STEPS_PER_DEG = 1e9 / 360
-    """The number of steps per degree for NCO phase instructions arguments."""
-    NCO_FREQ_STEPS_PER_HZ = 4.0
-    """The number of steps per Hz for the NCO set_freq instruction."""
-    NCO_FREQ_LIMIT_STEPS = 2e9
-    """The maximum and minimum frequency expressed in steps for the NCO set_freq instruction.
-    For the minimum we multiply by -1."""
-    NUMBER_OF_SEQUENCERS_QCM = 6
-    """Number of sequencers supported by a QCM/QCM-RF in the latest firmware."""
-    NUMBER_OF_SEQUENCERS_QRM = 6
-    """Number of sequencers supported by a QRM/QRM-RF in the latest firmware."""
-    NUMBER_OF_REGISTERS: int = 64
-    """Number of registers available in the Qblox sequencers."""
-    MAX_SAMPLE_SIZE_SCOPE_ACQUISITIONS: int = 16384
-    """Maximal amount of scope trace acquisition datapoints returned."""
-    MAX_SAMPLE_SIZE_WAVEFORMS: int = 16384
-    """Maximal amount of samples in the waveforms to be uploaded to a sequencer."""
-    GRID_TIME = 4  # ns
-    """
-    Clock period of the sequencers. All time intervals used must be multiples of this value.
-    """
-    LOOP_UNROLL_THRESHOLD = 4
-    """
-    Size above which loops have tolerable overhead
-    """
-
-
 class Opcode(Enum):
     # Control
     NEW_LINE = "\n"

--- a/src/tests/qblox/builder_nuggets.py
+++ b/src/tests/qblox/builder_nuggets.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from qat.purr.compiler.instructions import SweepValue, Variable
+from qat.purr.compiler.runtime import get_builder
+
+
+def resonator_spect(model):
+    qubit = model.get_qubit(0)
+    measure_channel = qubit.get_measure_channel()
+    acquire_channel = qubit.get_acquire_channel()
+    assert acquire_channel == measure_channel
+
+    num_points = 10
+    freq_range = 50e6
+    center_freq = qubit.get_acquire_channel().frequency
+    freqs = center_freq + np.linspace(-freq_range, freq_range, num_points)
+    var_name = f"freq{qubit.index}"
+    output_variable = f"Q{qubit.index}"
+
+    builder = (
+        get_builder(model)
+        .sweep(SweepValue(var_name, freqs))
+        .device_assign(measure_channel, "frequency", Variable(var_name))
+        .device_assign(acquire_channel, "frequency", Variable(var_name))
+        .measure_mean_signal(qubit, output_variable)
+        .repeat(1000, 500e-6)
+    )
+    return builder

--- a/src/tests/qblox/conftest.py
+++ b/src/tests/qblox/conftest.py
@@ -2,15 +2,17 @@ import pytest
 
 from qat.purr.backends.qblox.live import QbloxLiveHardwareModel
 
-from .utils import setup_qblox_hardware_model
+from .utils import ClusterInfo, setup_qblox_hardware_model
 
 
 @pytest.fixture
 def model(request):
-    cluster_kit = request.param
-    name = request.node.originalname
+    info: ClusterInfo = request.param
+    if not info.name:
+        info.name = request.node.originalname
+
     model = QbloxLiveHardwareModel()
-    setup_qblox_hardware_model(model, cluster_kit, name)
+    setup_qblox_hardware_model(model, info)
     model.control_hardware.connect()
     yield model
     model.control_hardware.disconnect()

--- a/src/tests/qblox/test_codegen.py
+++ b/src/tests/qblox/test_codegen.py
@@ -12,11 +12,12 @@ from qat.purr.compiler.emitter import InstructionEmitter
 from qat.purr.compiler.instructions import Acquire, MeasurePulse
 from qat.purr.compiler.runtime import get_builder
 from qat.purr.utils.logger import get_default_logger
+from tests.qblox.utils import ClusterInfo
 
 log = get_default_logger()
 
 
-@pytest.mark.parametrize("model", [None], indirect=True)
+@pytest.mark.parametrize("model", [ClusterInfo()], indirect=True)
 class TestQbloxEmitter:
     def test_play_guassian(self, model):
         width = 100e-9
@@ -109,5 +110,6 @@ class TestQbloxEmitter:
         assert isinstance(channel, QbloxPhysicalChannel)
         assert isinstance(channel.baseband, QbloxPhysicalBaseband)
         assert len(channel.config.sequencers) > 0
-        for sequencer in channel.config.sequencers.values():
-            assert sequencer.square_weight_acq.integration_length == int(time * 1e9)
+        assert package.sequencer_config.square_weight_acq.integration_length == int(
+            time * 1e9
+        )

--- a/src/tests/qblox/test_config.py
+++ b/src/tests/qblox/test_config.py
@@ -1,0 +1,249 @@
+import uuid
+
+import pytest
+from qblox_instruments import Cluster
+from qblox_instruments.qcodes_drivers.module import Module
+from qblox_instruments.qcodes_drivers.sequencer import Sequencer
+
+from qat.purr.backends.qblox.codegen import QbloxEmitter, calculate_duration
+from qat.purr.backends.qblox.config import (
+    ModuleConfig,
+    QbloxConfig,
+    QcmConfigHelper,
+    QcmRfConfigHelper,
+    QrmConfigHelper,
+    QrmRfConfigHelper,
+    SequencerConfig,
+)
+from qat.purr.compiler.devices import PulseShapeType
+from qat.purr.compiler.emitter import InstructionEmitter
+from qat.purr.compiler.instructions import Acquire
+from qat.purr.compiler.runtime import get_builder
+from tests.qblox.utils import DUMMY_CONFIG, ClusterInfo, MixerTestValues
+
+
+class TestQbloxConfigMixin:
+    @staticmethod
+    def extract_lo_and_nco_freqs(target):
+        if target.fixed_if:  # NCO freq constant
+            nco_freq = target.baseband_if_frequency
+            lo_freq = target.frequency - nco_freq
+        else:  # LO freq constant
+            lo_freq = target.baseband_frequency
+            nco_freq = target.frequency - lo_freq
+
+        return lo_freq, nco_freq
+
+    @staticmethod
+    def setup_qcm_mixer_config(module_config: ModuleConfig, i_offset, q_offset):
+        module_config.offset.out0 = i_offset
+        module_config.offset.out1 = q_offset
+        module_config.offset.out2 = i_offset
+        module_config.offset.out3 = q_offset
+
+    @staticmethod
+    def setup_qcm_rf_mixer_config(module_config: ModuleConfig, i_offset, q_offset):
+        module_config.offset.out0_path0 = i_offset
+        module_config.offset.out0_path1 = q_offset
+        module_config.offset.out1_path0 = i_offset
+        module_config.offset.out1_path1 = q_offset
+
+    @staticmethod
+    def setup_qrm_mixer_config(module_config: ModuleConfig, i_offset, q_offset):
+        module_config.offset.out0 = i_offset
+        module_config.offset.out1 = q_offset
+        module_config.offset.in0 = i_offset
+        module_config.offset.in1 = q_offset
+
+    @staticmethod
+    def setup_qrm_rf_mixer_config(module_config: ModuleConfig, i_offset, q_offset):
+        module_config.offset.out0_path0 = i_offset
+        module_config.offset.out0_path1 = q_offset
+        module_config.offset.in0_path0 = i_offset
+        module_config.offset.in0_path1 = q_offset
+
+    @staticmethod
+    def setup_sequencer_mixer_config(seq_config: SequencerConfig, phase_offset, gain_ratio):
+        seq_config.mixer.gain_ratio = gain_ratio
+        seq_config.mixer.phase_offset = phase_offset
+
+
+@pytest.mark.parametrize("model", [ClusterInfo()], indirect=True)
+class TestSequencerConfig(TestQbloxConfigMixin):
+    def test_lo_and_nco_freq(self, model):
+        width = 100e-9
+        amp = 0.5
+        qubit = model.get_qubit(0)
+        drive_channel = qubit.get_drive_channel()
+        measure_channel = qubit.get_measure_channel()
+
+        builder = (
+            get_builder(model)
+            .pulse(drive_channel, PulseShapeType.SQUARE, width=width, amp=amp)
+            .measure_mean_z(qubit)
+        )
+        qat_file = InstructionEmitter().emit(builder.instructions, model)
+        packages = QbloxEmitter().emit(qat_file)
+
+        assert len(packages) == 2
+
+        # Drive
+        drive_pkg = next((pkg for pkg in packages if pkg.target == drive_channel))
+        lo_freq, nco_freq = self.extract_lo_and_nco_freqs(drive_channel)
+        module, sequencer = model.control_hardware.install(drive_pkg)
+        assert sequencer.nco_freq() == nco_freq
+        if module.out0_lo_en():
+            assert module.out0_lo_freq() == lo_freq
+        if module.out1_lo_en():
+            assert module.out1_lo_freq() == lo_freq
+
+        # Measurement
+        acquire = next(
+            (inst for inst in qat_file.instructions if isinstance(inst, Acquire))
+        )
+        measure_pkg = next((pkg for pkg in packages if pkg.target == measure_channel))
+        module, sequencer = model.control_hardware.install(measure_pkg)
+        hwm_seq_config = measure_channel.physical_channel.config.sequencers[
+            sequencer.seq_idx
+        ]
+        pkg_seq_config = measure_pkg.sequencer_config
+
+        assert pkg_seq_config.square_weight_acq.integration_length == calculate_duration(
+            acquire
+        )
+        assert (
+            pkg_seq_config.square_weight_acq.integration_length
+            == hwm_seq_config.square_weight_acq.integration_length
+        )
+        assert (
+            sequencer.integration_length_acq()
+            == pkg_seq_config.square_weight_acq.integration_length
+        )
+
+        lo_freq, nco_freq = self.extract_lo_and_nco_freqs(measure_channel)
+        assert sequencer.nco_freq() == nco_freq
+        if module.out0_in0_lo_en():
+            assert module.out0_in0_lo_freq() == lo_freq
+
+
+class TestMixerConfig(TestQbloxConfigMixin):
+    mixer_values = MixerTestValues()
+
+    @pytest.mark.skip("Needs config implementation for QCM")
+    @pytest.mark.parametrize("phase_offset", mixer_values.phase_offsets)
+    @pytest.mark.parametrize("gain_ratio", mixer_values.gain_ratios)
+    @pytest.mark.parametrize("i_offset", mixer_values.qcm_i_offsets)
+    @pytest.mark.parametrize("q_offset", mixer_values.qcm_q_offsets)
+    def test_qcm_mixer_config(self, request, phase_offset, gain_ratio, i_offset, q_offset):
+        module_config = ModuleConfig()
+        seq_idx, sequencer_config = 0, SequencerConfig()
+        config = QbloxConfig(module=module_config, sequencers={seq_idx: sequencer_config})
+
+        name = f"{request.node.originalname}_{uuid.uuid4()}"
+        cluster: Cluster = Cluster(name=name, dummy_cfg=DUMMY_CONFIG)
+        module: Module = next(
+            (
+                m
+                for m in cluster.modules
+                if m.present() and m.is_qcm_type and not m.is_rf_type
+            )
+        )
+        sequencer: Sequencer = module.sequencers[seq_idx]
+
+        self.setup_qcm_mixer_config(module_config, i_offset, q_offset)
+        self.setup_sequencer_mixer_config(sequencer_config, phase_offset, gain_ratio)
+        QcmConfigHelper(config).configure(module, sequencer)
+
+        assert module.out0_offset() == module_config.offset.out0
+        assert module.out1_offset() == module_config.offset.out1
+        assert module.out2_offset() == module_config.offset.out2
+        assert module.out3_offset() == module_config.offset.out3
+
+    @pytest.mark.parametrize("phase_offset", mixer_values.phase_offsets)
+    @pytest.mark.parametrize("gain_ratio", mixer_values.gain_ratios)
+    @pytest.mark.parametrize("i_offset", mixer_values.qcm_rf_i_offsets)
+    @pytest.mark.parametrize("q_offset", mixer_values.qcm_rf_q_offsets)
+    def test_qcm_rf_mixer_config(
+        self, request, phase_offset, gain_ratio, i_offset, q_offset
+    ):
+        module_config = ModuleConfig()
+        seq_idx, sequencer_config = 0, SequencerConfig()
+        config = QbloxConfig(module=module_config, sequencers={seq_idx: sequencer_config})
+
+        name = f"{request.node.originalname}_{uuid.uuid4()}"
+        cluster: Cluster = Cluster(name=name, dummy_cfg=DUMMY_CONFIG)
+        module: Module = next(
+            (m for m in cluster.modules if m.present() and m.is_qcm_type and m.is_rf_type)
+        )
+        sequencer: Sequencer = module.sequencers[seq_idx]
+
+        self.setup_qcm_rf_mixer_config(module_config, i_offset, q_offset)
+        self.setup_sequencer_mixer_config(sequencer_config, phase_offset, gain_ratio)
+        QcmRfConfigHelper(config).configure(module, sequencer)
+
+        assert module.out0_offset_path0() == module_config.offset.out0_path0
+        assert module.out0_offset_path1() == module_config.offset.out0_path1
+        assert module.out1_offset_path0() == module_config.offset.out1_path0
+        assert module.out1_offset_path1() == module_config.offset.out1_path1
+
+    @pytest.mark.skip("Needs config implementation for QRM")
+    @pytest.mark.parametrize("phase_offset", mixer_values.phase_offsets)
+    @pytest.mark.parametrize("gain_ratio", mixer_values.gain_ratios)
+    @pytest.mark.parametrize("i_offset", mixer_values.qrm_i_offsets)
+    @pytest.mark.parametrize("q_offset", mixer_values.qrm_q_offsets)
+    def test_qrm_mixer_config(self, request, phase_offset, gain_ratio, i_offset, q_offset):
+        module_config = ModuleConfig()
+        seq_idx, sequencer_config = 0, SequencerConfig()
+        config = QbloxConfig(module=module_config, sequencers={seq_idx: sequencer_config})
+
+        name = f"{request.node.originalname}_{uuid.uuid4()}"
+        cluster: Cluster = Cluster(name=name, dummy_cfg=DUMMY_CONFIG)
+        module: Module = next(
+            (
+                m
+                for m in cluster.modules
+                if m.present() and m.is_qrm_type and not m.is_rf_type
+            )
+        )
+        sequencer: Sequencer = module.sequencers[seq_idx]
+
+        self.setup_qrm_mixer_config(module_config, i_offset, q_offset)
+        self.setup_sequencer_mixer_config(sequencer_config, phase_offset, gain_ratio)
+        QrmConfigHelper(config).configure(module, sequencer)
+
+        assert module.out0_offset() == module_config.offset.out0
+        assert module.out1_offset() == module_config.offset.out1
+        assert module.in0_offset() == module_config.offset.in0
+        assert module.in1_offset() == module_config.offset.in1
+
+    @pytest.mark.parametrize("phase_offset", mixer_values.phase_offsets)
+    @pytest.mark.parametrize("gain_ratio", mixer_values.gain_ratios)
+    @pytest.mark.parametrize("i_offset", mixer_values.qrm_rf_i_offsets)
+    @pytest.mark.parametrize("q_offset", mixer_values.qrm_rf_q_offsets)
+    def test_qrm_rf_mixer_config(
+        self, request, phase_offset, gain_ratio, i_offset, q_offset
+    ):
+        module_config = ModuleConfig()
+        seq_idx, sequencer_config = 0, SequencerConfig()
+        config = QbloxConfig(module=module_config, sequencers={seq_idx: sequencer_config})
+
+        name = f"{request.node.originalname}_{uuid.uuid4()}"
+        cluster: Cluster = Cluster(name=name, dummy_cfg=DUMMY_CONFIG)
+        module: Module = next(
+            (m for m in cluster.modules if m.present() and m.is_qrm_type and m.is_rf_type)
+        )
+        sequencer: Sequencer = module.sequencers[seq_idx]
+
+        self.setup_qrm_rf_mixer_config(module_config, i_offset, q_offset)
+        self.setup_sequencer_mixer_config(sequencer_config, phase_offset, gain_ratio)
+        QrmRfConfigHelper(config).configure(module, sequencer)
+
+        assert module.out0_offset_path0() == module_config.offset.out0_path0
+        assert module.out0_offset_path1() == module_config.offset.out0_path1
+
+        # TODO - potential bug with the dummy structures
+        with pytest.raises(AssertionError):
+            assert module.in0_offset_path0() == module_config.offset.in0_path0
+
+        with pytest.raises(AssertionError):
+            assert module.in0_offset_path1() == module_config.offset.in0_path1

--- a/src/tests/qblox/test_device.py
+++ b/src/tests/qblox/test_device.py
@@ -7,11 +7,12 @@ from qat.purr.compiler.emitter import InstructionEmitter
 from qat.purr.compiler.instructions import SweepValue, Variable
 from qat.purr.compiler.runtime import execute_instructions, get_builder
 from qat.purr.utils.logger import get_default_logger
+from tests.qblox.utils import ClusterInfo
 
 log = get_default_logger()
 
 
-@pytest.mark.parametrize("model", [None], indirect=True)
+@pytest.mark.parametrize("model", [ClusterInfo()], indirect=True)
 class TestDummyQbloxControlHardware:
     def test_instruction_execution(self, model):
         amp = 1

--- a/src/tests/qblox/test_live.py
+++ b/src/tests/qblox/test_live.py
@@ -5,11 +5,12 @@ from qat.purr.compiler.devices import PulseShapeType
 from qat.purr.compiler.instructions import SweepValue, Variable
 from qat.purr.compiler.runtime import execute_instructions, get_builder
 from qat.purr.utils.logger import get_default_logger
+from tests.qblox.utils import ClusterInfo
 
 log = get_default_logger()
 
 
-@pytest.mark.parametrize("model", [None], indirect=True)
+@pytest.mark.parametrize("model", [ClusterInfo()], indirect=True)
 class TestQbloxLiveEngine:
     def test_measure_amp_sweep(self, model):
         engine = model.create_engine()


### PR DESCRIPTION
- Qblox (sequencer) config now comes from two sources: the hardware models and the codegen.
- Integration length on the sequencer is now being "properly" dynamically set when readout width changes (following SNR optimisation pass for example). Solution to this actually enables a lot of flexibility (via the builder)
- Enable setting up a few more fields important for mixer calibration
- Minor test refactoring and cleanup