### PR TITLE
qiskit-ignis is unmaintained. Moving to qiskit-experiments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ toml = "^0.10.2"
 pytket = "1.31.0"
 qiskit = "^0.45.0"
 qiskit-optimization = "~=0.4.0"
-qiskit-ignis = "~=0.7"
+qiskit-experiments = "~=0.7"
 qiskit-aer = "^0.13.0"
 scipy = ">=1.13.1"
 pyqir = { version = "^0.8.0a1", allow-prereleases = true }

--- a/src/qat/purr/utils/benchmarking.py
+++ b/src/qat/purr/utils/benchmarking.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 
-import qiskit.ignis.verification.randomized_benchmarking as rb
+import qiskit_experiments.library.randomized_benchmarking as rb
 
 from qat.purr.compiler.runtime import get_builder
 from qat.purr.integrations.qasm import Qasm2Parser


### PR DESCRIPTION
[Last `qiskit-ignis` release](https://github.com/qiskit-community/qiskit-ignis/releases/latest) was on May 2022 and it is now unmaintained. It is used in a single file, which seems like a drop-in replacement:  

https://github.com/oqc-community/qat/blob/ea6a1893c4915f7c72c3756b6238d92b1eb5deb1/src/qat/purr/utils/benchmarking.py#L4

According with [the migration guide](https://github.com/qiskit-community/qiskit-ignis?tab=readme-ov-file#migration-guide),  `qiskit.ignis.verification.randomized_benchmarking` is replaced by `qiskit_experiments.library.randomized_benchmarking`, from [`qiskit-experiments`](https://github.com/qiskit-community/qiskit-experiments).


