### PR TITLE
Give ID to setup python step

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -30,9 +30,10 @@ jobs:
 
       - name: Set up Python 3.x
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
+          cache: 'poetry'
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -75,10 +75,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.x
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -33,7 +33,6 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python }}
-          cache: 'poetry'
 
       - name: Install Poetry
         uses: snok/install-poetry@v1


### PR DESCRIPTION
The "Load cached venv" step was unable to append the python version to the name of the python venv cache. This was causing sporadic failures of the pipelines. This change will give the step "Set up Python 3.x" and ID "setup-python" so it can correctly fetch the cache. 