### PR TITLE
Rename classes with Test in the name.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ filterwarnings = [
     #
     # Temporary default for pre-existing issues. Tickets exist for addressing these:
     "default::pytest.PytestUnhandledThreadExceptionWarning",
-    "default::pytest.PytestCollectionWarning",
     "default:::qutip",
     "default:::qcodes",
     # TODO: Watch Qiskit BasicSimulator file for update to the new run flow.

--- a/tests/qat/qasm_utils.py
+++ b/tests/qat/qasm_utils.py
@@ -11,36 +11,36 @@ from qat.purr.compiler.runtime import get_builder
 from qat.purr.integrations.qasm import Qasm2Parser, qasm_from_file
 
 
-class TestFileType(Enum):
+class ProgramFileType(Enum):
     QASM2 = (auto(),)
     QASM3 = (auto(),)
     QIR = auto()
     OPENPULSE = auto()
 
 
-def get_test_files_dir(ir_type: TestFileType):
-    if ir_type == TestFileType.QASM3:
+def get_test_files_dir(ir_type: ProgramFileType):
+    if ir_type == ProgramFileType.QASM3:
         return abspath(join(dirname(__file__), "files", "qasm", "qasm3"))
-    elif ir_type == TestFileType.QASM2:
+    elif ir_type == ProgramFileType.QASM2:
         return abspath(join(dirname(__file__), "files", "qasm", "qasm2"))
-    elif ir_type == TestFileType.QIR:
+    elif ir_type == ProgramFileType.QIR:
         return abspath(join(dirname(__file__), "files", "qir"))
-    elif ir_type == TestFileType.OPENPULSE:
+    elif ir_type == ProgramFileType.OPENPULSE:
         return abspath(join(dirname(__file__), "files", "qasm", "qasm3", "openpulse_tests"))
     else:
         raise ValueError("Test file directory dosen't exist for this IR type.")
 
 
-def get_test_file_path(ir_type: TestFileType, file_name):
+def get_test_file_path(ir_type: ProgramFileType, file_name):
     return join(get_test_files_dir(ir_type), file_name)
 
 
 def get_qasm3(file_name):
-    return qasm_from_file(get_test_file_path(TestFileType.QASM3, file_name))
+    return qasm_from_file(get_test_file_path(ProgramFileType.QASM3, file_name))
 
 
 def get_qasm2(file_name):
-    return qasm_from_file(get_test_file_path(TestFileType.QASM2, file_name))
+    return qasm_from_file(get_test_file_path(ProgramFileType.QASM2, file_name))
 
 
 def parse_and_apply_optimiziations(

--- a/tests/qat/test_config.py
+++ b/tests/qat/test_config.py
@@ -19,7 +19,7 @@ from qat.purr.compiler.config import (
 )
 from qat.purr.compiler.instructions import Delay
 from qat.qat import execute_with_metrics
-from tests.qat.qasm_utils import TestFileType, get_test_file_path
+from tests.qat.qasm_utils import ProgramFileType, get_test_file_path
 
 SUPPORTED_CONFIG_VERSIONS = ["v02", "v1"]
 
@@ -185,7 +185,7 @@ class TestConfigGeneral:
 
     @pytest.mark.parametrize("version", SUPPORTED_CONFIG_VERSIONS)
     def test_runs_successfully_with_config(self, version):
-        program = get_test_file_path(TestFileType.QASM2, "ghz.qasm")
+        program = get_test_file_path(ProgramFileType.QASM2, "ghz.qasm")
         hardware = get_default_echo_hardware()
         serialised_data = _get_contents(f"serialised_full_compiler_config_{version}.json")
         deserialised_conf = CompilerConfig.create_from_json(

--- a/tests/qat/test_logger.py
+++ b/tests/qat/test_logger.py
@@ -87,7 +87,7 @@ class TestFileLogger:
                 assert regex_match.group(1) == msg
             file_handler.close()
 
-    class TestFileLoggerHandler(logger.FileLoggerHandler):
+    class FakeFileLoggerHandler(logger.FileLoggerHandler):
         initial_text = "Initial text"
 
         def create_initial_file(self):
@@ -103,7 +103,7 @@ class TestFileLogger:
         ):
             file_logger.removeHandler(file_handler)
             file_handler.close()
-            file_handler = self.TestFileLoggerHandler(
+            file_handler = self.FakeFileLoggerHandler(
                 os.path.join(
                     logs_path,
                     "initial_test_file_initial_text_is_written_if_specified.txt",
@@ -116,7 +116,7 @@ class TestFileLogger:
 
             with open(file_handler.baseFilename, "r") as f:
                 text = f.read().split("\n")
-                assert text[0] == self.TestFileLoggerHandler.initial_text
+                assert text[0] == self.FakeFileLoggerHandler.initial_text
                 regex_match = re.match(info_msg_pattern, text[1] + "\n")
                 assert regex_match
                 assert regex_match.group(1) == msg

--- a/tests/qat/test_qasm.py
+++ b/tests/qat/test_qasm.py
@@ -72,7 +72,7 @@ from qat.purr.integrations.qiskit import QatBackend
 from qat.purr.integrations.tket import TketBuilder, TketQasmParser
 from qat.qat import execute, execute_qasm, fetch_frontend
 from tests.qat.qasm_utils import (
-    TestFileType,
+    ProgramFileType,
     get_qasm2,
     get_qasm3,
     get_test_file_path,
@@ -491,7 +491,7 @@ class TestExecutionFrontend:
 
     def test_valid_qasm_path(self):
         hardware = get_default_echo_hardware(2)
-        execute(get_test_file_path(TestFileType.QASM2, "basic.qasm"), hardware=hardware)
+        execute(get_test_file_path(ProgramFileType.QASM2, "basic.qasm"), hardware=hardware)
 
     def test_quality_couplings(self):
         qasm_string = get_qasm2("basic.qasm")
@@ -819,7 +819,7 @@ class TestExecutionFrontend:
         frontend = fetch_frontend(qasm3_string, use_experimental=use_experimental)
         assert isinstance(frontend, frontend_mod.QASMFrontend)
 
-        qir_string = get_test_file_path(TestFileType.QIR, "generator-bell.ll")
+        qir_string = get_test_file_path(ProgramFileType.QIR, "generator-bell.ll")
         frontend = fetch_frontend(qir_string, use_experimental=use_experimental)
         assert isinstance(frontend, frontend_mod.QIRFrontend)
 

--- a/tests/qat/test_qat.py
+++ b/tests/qat/test_qat.py
@@ -5,13 +5,13 @@ import pytest
 from qat.purr.backends.echo import EchoEngine, get_default_echo_hardware
 from qat.purr.compiler.config import CompilerConfig, MetricsType, QuantumResultsFormat
 from qat.qat import execute_with_metrics
-from tests.qat.qasm_utils import TestFileType, get_test_file_path
+from tests.qat.qasm_utils import ProgramFileType, get_test_file_path
 from tests.qat.utils import ListReturningEngine
 
 
 @pytest.mark.parametrize(
     ("input_string", "file_type", "instruction_length"),
-    [("ghz.qasm", TestFileType.QASM2, 196)],
+    [("ghz.qasm", ProgramFileType.QASM2, 196)],
 )
 def test_all_metrics_are_returned(input_string, file_type, instruction_length):
     program = get_test_file_path(file_type, input_string)
@@ -22,7 +22,9 @@ def test_all_metrics_are_returned(input_string, file_type, instruction_length):
     assert metrics["optimized_instruction_count"] == instruction_length
 
 
-@pytest.mark.parametrize(("input_string", "file_type"), [("ghz.qasm", TestFileType.QASM2)])
+@pytest.mark.parametrize(
+    ("input_string", "file_type"), [("ghz.qasm", ProgramFileType.QASM2)]
+)
 def test_only_optim_circuitmetrics_are_returned(input_string, file_type):
     program = get_test_file_path(file_type, input_string)
     hardware = get_default_echo_hardware()
@@ -33,7 +35,9 @@ def test_only_optim_circuitmetrics_are_returned(input_string, file_type):
     assert metrics["optimized_instruction_count"] is None
 
 
-@pytest.mark.parametrize(("input_string", "file_type"), [("ghz.qasm", TestFileType.QASM2)])
+@pytest.mark.parametrize(
+    ("input_string", "file_type"), [("ghz.qasm", ProgramFileType.QASM2)]
+)
 def test_only_inst_len_circuitmetrics_are_returned(input_string, file_type):
     program = get_test_file_path(file_type, input_string)
     hardware = get_default_echo_hardware()
@@ -48,9 +52,9 @@ def test_only_inst_len_circuitmetrics_are_returned(input_string, file_type):
 @pytest.mark.parametrize(
     ("input_string", "file_type"),
     [
-        ("ghz.qasm", TestFileType.QASM2),
-        ("basic.qasm", TestFileType.QASM3),
-        ("generator-bell.ll", TestFileType.QIR),
+        ("ghz.qasm", ProgramFileType.QASM2),
+        ("basic.qasm", ProgramFileType.QASM3),
+        ("generator-bell.ll", ProgramFileType.QIR),
     ],
 )
 def test_batched_execution(input_string, file_type, engine):

--- a/tests/qat/test_qir.py
+++ b/tests/qat/test_qir.py
@@ -13,7 +13,7 @@ from qat.purr.compiler.builders import InstructionBuilder
 from qat.purr.compiler.config import CompilerConfig
 from qat.purr.integrations.qir import QIRParser
 from qat.qat import execute, execute_qir
-from tests.qat.qasm_utils import TestFileType, get_test_file_path
+from tests.qat.qasm_utils import ProgramFileType, get_test_file_path
 from tests.qat.utils import get_jagged_echo_hardware
 
 
@@ -40,7 +40,7 @@ class TestQIR:
 
     def test_valid_ll_path(self):
         execute(
-            get_test_file_path(TestFileType.QIR, "generator-bell.ll"),
+            get_test_file_path(ProgramFileType.QIR, "generator-bell.ll"),
             get_default_echo_hardware(2),
         )
 
@@ -59,7 +59,7 @@ class TestQIR:
 
     def test_cudaq_input(self):
         results = execute(
-            get_test_file_path(TestFileType.QIR, "basic_cudaq.ll"),
+            get_test_file_path(ProgramFileType.QIR, "basic_cudaq.ll"),
             get_default_echo_hardware(6),
         )
 

--- a/tests/qat/test_quantum_backend.py
+++ b/tests/qat/test_quantum_backend.py
@@ -37,7 +37,7 @@ from tests.qat.qasm_utils import get_qasm2
 from tests.qat.test_readout_mitigation import apply_error_mitigation_setup
 
 
-class TestBaseQuantumExecution(LiveDeviceEngine):
+class FakeBaseQuantumExecution(LiveDeviceEngine):
     baseband_frequencies = {}
     buffers = {}
 
@@ -140,8 +140,8 @@ def get_test_model() -> QuantumHardwareModel:
     return model
 
 
-def get_test_execution_engine(model) -> TestBaseQuantumExecution:
-    return TestBaseQuantumExecution(model)
+def get_test_execution_engine(model) -> FakeBaseQuantumExecution:
+    return FakeBaseQuantumExecution(model)
 
 
 def get_test_runtime(model) -> QuantumRuntime:
@@ -592,7 +592,7 @@ class TestBaseQuantum:
     def test_combining_python_list_results_succeeds(
         self, pre_combine, batch_results, post_combine
     ):
-        results = TestBaseQuantumExecution._accumulate_results(pre_combine, batch_results)
+        results = FakeBaseQuantumExecution._accumulate_results(pre_combine, batch_results)
         assert results == post_combine
 
     @pytest.mark.parametrize(
@@ -604,7 +604,7 @@ class TestBaseQuantum:
     def test_combining_numpy_array_results_succeeds(
         self, pre_combine, batch_results, post_combine
     ):
-        results = TestBaseQuantumExecution._accumulate_results(pre_combine, batch_results)
+        results = FakeBaseQuantumExecution._accumulate_results(pre_combine, batch_results)
         assert results.keys() == post_combine.keys()
         for k in results.keys():
             assert results[k].tolist() == post_combine[k].tolist()
@@ -620,7 +620,7 @@ class TestBaseQuantum:
     )
     def test_combining_results_fails(self, pre_combine, batch_results):
         with pytest.raises(ValueError):
-            TestBaseQuantumExecution._accumulate_results(pre_combine, batch_results)
+            FakeBaseQuantumExecution._accumulate_results(pre_combine, batch_results)
 
     @pytest.mark.parametrize(
         "repeat_count, repeat_limit, expected_batches",

--- a/tests/qat/test_serializer.py
+++ b/tests/qat/test_serializer.py
@@ -7,30 +7,30 @@ from qat.purr.utils.serializer import json_dumps, json_loads
 
 
 @dataclass
-class TestDataClass:
+class FakeDataClass:
     field1: int
     field2: str
     field3: dict
     field4: str = "Default"
 
 
-class TestClass:
+class FakeClass:
     def __init__(self, name: str):
         self.field1 = name
         self.field2 = True
 
 
-class TestDerivedClass(TestClass):
+class FakeDerivedClass(FakeClass):
     def __init__(self, value: int):
         super().__init__("DerivedClass")
         self.field3 = value
 
 
 @dataclass
-class TestDataClassWithCustomClass:
+class FakeDataClassWithCustomClass:
     field1: int
     field2: str
-    field3: TestClass
+    field3: FakeClass
 
 
 class TestCustomJSONEncoder:
@@ -65,9 +65,9 @@ class TestCustomJSONEncoder:
         assert loaded_obj is None
 
     def test_serialize_dataclass(self):
-        test_obj = TestDataClass(23, "Hello World!", {"key1": "data1", "key2": "data2"})
+        test_obj = FakeDataClass(23, "Hello World!", {"key1": "data1", "key2": "data2"})
         serialized_obj = json_dumps(test_obj)
-        loaded_obj: TestDataClass = json_loads(serialized_obj)
+        loaded_obj: FakeDataClass = json_loads(serialized_obj)
         assert test_obj.field1 == loaded_obj.field1
         assert test_obj.field2 == loaded_obj.field2
         assert test_obj.field3 == loaded_obj.field3
@@ -75,7 +75,7 @@ class TestCustomJSONEncoder:
         assert test_obj.__class__ == loaded_obj.__class__
 
     def test_serialize_basic_custom_class(self):
-        test_obj = TestClass("TestParameter")
+        test_obj = FakeClass("TestParameter")
         serialized_obj = json_dumps(test_obj)
         loaded_obj = json_loads(serialized_obj)
         assert test_obj.field1 == loaded_obj.field1
@@ -83,7 +83,7 @@ class TestCustomJSONEncoder:
         assert test_obj.__class__ == loaded_obj.__class__
 
     def test_serialize_inherited_custom_class(self):
-        test_obj = TestDerivedClass(34)
+        test_obj = FakeDerivedClass(34)
         serialized_obj = json_dumps(test_obj)
         loaded_obj = json_loads(serialized_obj)
         assert test_obj.field1, loaded_obj.field1
@@ -92,8 +92,8 @@ class TestCustomJSONEncoder:
         assert test_obj.__class__, loaded_obj.__class__
 
     def test_serialize_dataclass_with_custom_field(self):
-        test_obj = TestDataClassWithCustomClass(
-            23, "Hello World!", TestClass("TestParameter")
+        test_obj = FakeDataClassWithCustomClass(
+            23, "Hello World!", FakeClass("TestParameter")
         )
         serialized_obj = json_dumps(test_obj)
         loaded_obj = json_loads(serialized_obj)
@@ -119,15 +119,15 @@ class TestGetType:
         assert complex == serializer._get_type(str(type(complex(3, 4))))
 
     def test_get_type_custom_class(self):
-        assert TestClass == serializer._get_type(str(type(TestClass("something"))))
+        assert FakeClass == serializer._get_type(str(type(FakeClass("something"))))
 
-    class TestNestedClass:
+    class FakeNestedClass:
         def __init__(self, name: str):
             self.field1 = name
 
     def test_get_type_nested_custom_class(self):
-        assert TestGetType.TestNestedClass == serializer._get_type(
-            str(type(TestGetType.TestNestedClass("something")))
+        assert TestGetType.FakeNestedClass == serializer._get_type(
+            str(type(TestGetType.FakeNestedClass("something")))
         )
 
 
@@ -163,7 +163,7 @@ class TestDeserialize:
         assert loaded_obj is None
 
     def test_deserialize_dataclass(self):
-        test_obj = TestDataClass(23, "Hello World!", {"key1": "data1", "key2": "data2"})
+        test_obj = FakeDataClass(23, "Hello World!", {"key1": "data1", "key2": "data2"})
         formatted_json = {
             "$type": str(type(test_obj)),
             "$dataclass": True,
@@ -171,29 +171,29 @@ class TestDeserialize:
         }
         serialized_obj = json_dumps(formatted_json)
         loaded_obj = json_loads(serialized_obj)
-        assert type(loaded_obj) == TestDataClass
+        assert type(loaded_obj) == FakeDataClass
         assert is_dataclass(loaded_obj)
         assert asdict(loaded_obj) == asdict(test_obj)
 
     def test_deserialize_basic_custom_class(self):
-        test_obj = TestClass("TestParameter")
+        test_obj = FakeClass("TestParameter")
         formatted_json = {"$type": str(type(test_obj)), "$data": test_obj.__dict__}
         serialized_obj = json_dumps(formatted_json)
         loaded_obj = json_loads(serialized_obj)
-        assert type(loaded_obj) == TestClass
+        assert type(loaded_obj) == FakeClass
         assert loaded_obj.__dict__ == test_obj.__dict__
 
     def test_deserialize_inherited_custom_class(self):
-        test_obj = TestDerivedClass(34)
+        test_obj = FakeDerivedClass(34)
         formatted_json = {"$type": str(type(test_obj)), "$data": test_obj.__dict__}
         serialized_obj = json_dumps(formatted_json)
         loaded_obj = json_loads(serialized_obj)
-        assert type(loaded_obj) == TestDerivedClass
+        assert type(loaded_obj) == FakeDerivedClass
         assert loaded_obj.__dict__ == test_obj.__dict__
 
     def test_deserialize_dataclass_with_custom_field(self):
-        custom_field = TestClass("TestParameter")
-        test_obj = TestDataClassWithCustomClass(23, "Hello World!", custom_field)
+        custom_field = FakeClass("TestParameter")
+        test_obj = FakeDataClassWithCustomClass(23, "Hello World!", custom_field)
         formatted_json_data = asdict(test_obj)
         formatted_json_data.pop("field3")
         formatted_json_data["field3"] = {
@@ -207,11 +207,11 @@ class TestDeserialize:
         }
         serialized_obj = json_dumps(formatted_json)
         loaded_obj = json_loads(serialized_obj)
-        assert type(loaded_obj) == TestDataClassWithCustomClass
+        assert type(loaded_obj) == FakeDataClassWithCustomClass
         assert is_dataclass(loaded_obj)
         assert loaded_obj.field1 == test_obj.field1
         assert loaded_obj.field2 == test_obj.field2
-        assert type(loaded_obj.field3) == TestClass
+        assert type(loaded_obj.field3) == FakeClass
         assert loaded_obj.field3.__dict__ == custom_field.__dict__
 
     def test_deserialize_complex(self):

--- a/tests/qat/test_verification.py
+++ b/tests/qat/test_verification.py
@@ -12,7 +12,7 @@ from qat.purr.backends.verification import (
 )
 from qat.purr.compiler.config import CompilerConfig, Tket
 from qat.qat import execute
-from tests.qat.qasm_utils import TestFileType, get_qasm2, get_test_file_path
+from tests.qat.qasm_utils import ProgramFileType, get_qasm2, get_test_file_path
 
 
 class TestFirmwareVerificationEngines:
@@ -27,12 +27,12 @@ class TestFirmwareVerificationEngines:
     @pytest.mark.parametrize(
         ("input_string", "file_type", "is_valid"),
         [
-            ("primitives.qasm", TestFileType.QASM2, True),
-            ("ghz.qasm", TestFileType.QASM3, True),
-            ("ghz.qasm", TestFileType.QASM3, True),
-            ("bell_psi_plus.ll", TestFileType.QIR, True),
-            ("cross_ressonance.qasm", TestFileType.OPENPULSE, True),
-            ("long_qasm.qasm", TestFileType.QASM2, False),
+            ("primitives.qasm", ProgramFileType.QASM2, True),
+            ("ghz.qasm", ProgramFileType.QASM3, True),
+            ("ghz.qasm", ProgramFileType.QASM3, True),
+            ("bell_psi_plus.ll", ProgramFileType.QIR, True),
+            ("cross_ressonance.qasm", ProgramFileType.OPENPULSE, True),
+            ("long_qasm.qasm", ProgramFileType.QASM2, False),
         ],
     )
     def test_circuit_length_validation(self, input_string, file_type, is_valid):


### PR DESCRIPTION
Resolved Pytest Collection Warnings by renaming classes in the tests tree that should not have `Test` in the name.