### PR TITLE
Fix get_builder. Method will return a model for a passed in InstructionExecutionEngine

### DIFF
--- a/src/qat/purr/compiler/runtime.py
+++ b/src/qat/purr/compiler/runtime.py
@@ -304,9 +304,9 @@ def get_runtime(hardware: Union[QuantumExecutionEngine, QuantumHardwareModel]):
 
 
 def get_builder(
-    model: Union[QuantumHardwareModel, QuantumExecutionEngine]
+    model: Union[QuantumHardwareModel, InstructionExecutionEngine]
 ) -> QuantumInstructionBuilder:
-    if isinstance(model, QuantumExecutionEngine):
+    if isinstance(model, InstructionExecutionEngine):
         model = model.model
     return model.create_builder()
 


### PR DESCRIPTION
Issue link: https://github.com/oqc-community/qat/issues/164