### PR TITLE
Bugfix if last instruction was measure

### DIFF
--- a/src/qat/purr/compiler/runtime.py
+++ b/src/qat/purr/compiler/runtime.py
@@ -193,7 +193,7 @@ class QuantumRuntime(MetricsMixin):
         if self.engine is None:
             raise ValueError("No execution engine available.")
 
-        if isinstance(instructions, InstructionBuilder):
+        if isinstance(instructions, InstructionBuilder) or any([i for i in instructions if isinstance(i, InstructionBuilder)]):
             instructions = instructions.instructions
 
         if instructions is None or not any(instructions):

--- a/src/qat/purr/compiler/runtime.py
+++ b/src/qat/purr/compiler/runtime.py
@@ -5,6 +5,7 @@ from numbers import Number
 from typing import List, Optional, TypeVar, Union
 
 import numpy
+from purr.compiler.builders import FluidBuilderWrapper
 
 from qat.purr.compiler.builders import InstructionBuilder, QuantumInstructionBuilder
 from qat.purr.compiler.config import (
@@ -193,7 +194,9 @@ class QuantumRuntime(MetricsMixin):
         if self.engine is None:
             raise ValueError("No execution engine available.")
 
-        if isinstance(instructions, InstructionBuilder) or any([i for i in instructions if isinstance(i, InstructionBuilder)]):
+        if isinstance(instructions, InstructionBuilder) or isinstance(
+            instructions, FluidBuilderWrapper
+        ):
             instructions = instructions.instructions
 
         if instructions is None or not any(instructions):

--- a/src/qat/purr/compiler/runtime.py
+++ b/src/qat/purr/compiler/runtime.py
@@ -5,9 +5,12 @@ from numbers import Number
 from typing import List, Optional, TypeVar, Union
 
 import numpy
-from purr.compiler.builders import FluidBuilderWrapper
 
-from qat.purr.compiler.builders import InstructionBuilder, QuantumInstructionBuilder
+from qat.purr.compiler.builders import (
+    FluidBuilderWrapper,
+    InstructionBuilder,
+    QuantumInstructionBuilder,
+)
 from qat.purr.compiler.config import (
     CalibrationArguments,
     CompilerConfig,


### PR DESCRIPTION
Fixes bug with measure is the last instruction which returns tuple from `FluidBuilderWrapper`. Checks if iter has a builder and calls the builders instructions instead. This bug was found in the test case:
```
builder = (get_builder(model)
                   .X(drive_channel, np.pi / 2.0)
                   .measure(qubit))
results, _ = execute_instructions(engine, builder)
```
Which only returned a singular acquire. Instead of processing the drive pulse and measure.