### PR TITLE
fix: resolve flaky noise simulation test

### DIFF
--- a/tests/qat/test_readout_mitigation.py
+++ b/tests/qat/test_readout_mitigation.py
@@ -328,6 +328,8 @@ class TestOnNoisySimulator:
         q0_ro_fidelity_1=0.7,
         q1_ro_fidelity_0=0.9,
         q1_ro_fidelity_1=0.6,
+        threshold=0.051,
+        repeats=5
     ):
         assert len(bitstring) == 2
         circuit = QuantumCircuit(2, 2)
@@ -349,9 +351,15 @@ class TestOnNoisySimulator:
         eng.fidelity_r0 = [q0_ro_fidelity_0, q1_ro_fidelity_0]
         eng.fidelity_r1 = [q0_ro_fidelity_1, q1_ro_fidelity_1]
 
-        mitigated_result = execute_qasm(qasm, eng, self.config)["linear_readout_mitigation"]
-        for output_bits, probability in mitigated_result.items():
+        # Repeat results to reduce variance
+        results = {'00': 0.0, '01': 0.0, '10': 0.0, '11': 0.0}
+        for _ in range(repeats):
+            mitigated_result = execute_qasm(qasm, eng, self.config)["linear_readout_mitigation"]
+            for output_bits, probability in mitigated_result.items():
+                results[output_bits] += probability
+
+        for output_bits, probability in results.items():
             if output_bits == bitstring:
-                assert abs(1 - probability) < 0.051
+                assert abs(1 - probability / repeats) < threshold
             else:
-                assert abs(probability) < 0.051
+                assert abs(probability / repeats) < threshold

--- a/tests/qat/test_readout_mitigation.py
+++ b/tests/qat/test_readout_mitigation.py
@@ -329,7 +329,7 @@ class TestOnNoisySimulator:
         q1_ro_fidelity_0=0.9,
         q1_ro_fidelity_1=0.6,
         threshold=0.051,
-        repeats=5
+        repeats=5,
     ):
         assert len(bitstring) == 2
         circuit = QuantumCircuit(2, 2)
@@ -352,9 +352,11 @@ class TestOnNoisySimulator:
         eng.fidelity_r1 = [q0_ro_fidelity_1, q1_ro_fidelity_1]
 
         # Repeat results to reduce variance
-        results = {'00': 0.0, '01': 0.0, '10': 0.0, '11': 0.0}
+        results = {"00": 0.0, "01": 0.0, "10": 0.0, "11": 0.0}
         for _ in range(repeats):
-            mitigated_result = execute_qasm(qasm, eng, self.config)["linear_readout_mitigation"]
+            mitigated_result = execute_qasm(qasm, eng, self.config)[
+                "linear_readout_mitigation"
+            ]
             for output_bits, probability in mitigated_result.items():
                 results[output_bits] += probability
 


### PR DESCRIPTION
The test checks the functionality to mitigate the readout error using a linear model by running a noisy simulator. It checks that the returned mitigated results fall within a certain tolerance of the expected result.

The problem is that the results are statistical, and by chance can fall outside of this tolerance (it happened about 1% of the time in my checks...).

The solution here isn't a perfect one. As the test is implemented, it would be nearly impossible to reduce the chance to fail to zero in a meaningful way. I have just added some repeats in the experiment to reduce the variance of the (averaged) deviation with the expected result, which should make it pass more reliably. Maybe in the future we should reconsider the purpose of the test, as a test that relies on randomness is not ideal.