### PR TITLE
randomized_benchmarking bug

### DIFF
--- a/src/qat/purr/utils/benchmarking.py
+++ b/src/qat/purr/utils/benchmarking.py
@@ -21,6 +21,8 @@ def randomized_benchmarking(hardware, nseeds, *args, **kwargs):
     if "lengths" not in kwargs:
         # TODO: Find out why length 10 generates some broken DAG when re-parsed
         lengths = [1, 2, 4]
+    else:
+        lengths = kwargs.pop("lengths")
     if "physical_qubits" not in kwargs:
         physical_qubits = [0]
 

--- a/src/qat/purr/utils/benchmarking.py
+++ b/src/qat/purr/utils/benchmarking.py
@@ -18,13 +18,8 @@ def randomized_benchmarking(hardware, nseeds, *args, **kwargs):
     relates to the various benchmarking runs and a list of the sequence lengths.
     """
     # Due to the variable return value we can't directly unpack.
-    if "lengths" not in kwargs:
-        # TODO: Find out why length 10 generates some broken DAG when re-parsed
-        lengths = [1, 2, 4]
-    else:
-        lengths = kwargs.pop("lengths")
-    if "physical_qubits" not in kwargs:
-        physical_qubits = [0]
+    lengths = kwargs.pop("lengths", [1, 2, 4])
+    physical_qubits = kwargs.pop("physical_qubits", [0])
 
     results = dict()
     index = 0

--- a/tests/qat/test_benchmarking.py
+++ b/tests/qat/test_benchmarking.py
@@ -16,3 +16,13 @@ class TestBenchmarking:
             for inst in seed_list
         ]
         assert len(benchmarking_results) == 6
+
+    def test_randomized_benchmarking_lengths(self):
+        model = get_default_echo_hardware()
+        results, sequence_lengths = randomized_benchmarking(model, 2, lengths=[1, 2])
+        benchmarking_results = [
+            execute_instructions(model, inst)
+            for seed_list in results.values()
+            for inst in seed_list
+        ]
+        assert len(benchmarking_results) == 4


### PR DESCRIPTION
`randomized_benchmarking` throws error if lengths was given as key argument.