### PR TITLE
Only make releases from tags on main where poetry version matches tag

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
 jobs:
-  # @see https://stackoverflow.com/a/72959712/8179249
   check-current-branch:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -2,14 +2,35 @@ name: Publish package to PyPI and TestPyPI
 
 on:
   push:
-    branches: [ main ]
     tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
-
 jobs:
+  # @see https://stackoverflow.com/a/72959712/8179249
+  check-current-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.check_step.outputs.branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get current branch
+        id: check_step
+        # 1. Get the list of branches ref where this tag exists
+        # 2. Remove 'origin/' from that result
+        # 3. Put that string in output
+        # => We can now use function 'contains(list, item)''
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch="$(echo ${raw//origin\//} | tr -d '\n')"
+          echo "{name}=branch" >> $GITHUB_OUTPUT
+          echo "Branches where this tag exists : $branch."          
   build:
     name: Build
     runs-on: ubuntu-latest
-
+    needs: check-current-branch
+    # only run if tag is present on branch 'main'
+    if: contains(${{ needs.check-current-branch.outputs.branch }}, 'main')`
     steps:
     - uses: actions/checkout@v4
 
@@ -20,6 +41,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.x"
+    - name: Check poetry version matches tag
+      run: | 
+        POETRY_VERSION=$(poetry version -s)
+        TAG=$(echo $GITHUB_REF | cut -d / -f 3)
+        [ $POETRY_VERSION = $TAG ] 
     - name: Poetry install
       run: poetry install --sync
 


### PR DESCRIPTION
This changes our package publishing action to run on a tag push. Previously it was intended to run on a 'tag push on main' but in fact it was triggering on a tag OR main. The new flow will trigger on any tag but check that tag is a commit on main and abort if not (thanks to @matt-oqc for this fix on QAT-RPC).

It also checks that the poetry version (in pyproject.toml) precisely matches the tag.

Tag extraction uses https://stackoverflow.com/a/72959712/8179249