### PR TITLE
Measurement Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ logs/
 calibration_results/
 .coverage
 
+# Temp files
+**/*.tmp
+**/*.temp
+**/tmp.*
+
 # Docs
 docs/build/*
 docs/source/*

--- a/poetry.lock
+++ b/poetry.lock
@@ -992,53 +992,59 @@ typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "fonttools"
-version = "4.53.1"
+version = "4.54.0"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.53.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0679a30b59d74b6242909945429dbddb08496935b82f91ea9bf6ad240ec23397"},
-    {file = "fonttools-4.53.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8bf06b94694251861ba7fdeea15c8ec0967f84c3d4143ae9daf42bbc7717fe3"},
-    {file = "fonttools-4.53.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b96cd370a61f4d083c9c0053bf634279b094308d52fdc2dd9a22d8372fdd590d"},
-    {file = "fonttools-4.53.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1c7c5aa18dd3b17995898b4a9b5929d69ef6ae2af5b96d585ff4005033d82f0"},
-    {file = "fonttools-4.53.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e013aae589c1c12505da64a7d8d023e584987e51e62006e1bb30d72f26522c41"},
-    {file = "fonttools-4.53.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9efd176f874cb6402e607e4cc9b4a9cd584d82fc34a4b0c811970b32ba62501f"},
-    {file = "fonttools-4.53.1-cp310-cp310-win32.whl", hash = "sha256:c8696544c964500aa9439efb6761947393b70b17ef4e82d73277413f291260a4"},
-    {file = "fonttools-4.53.1-cp310-cp310-win_amd64.whl", hash = "sha256:8959a59de5af6d2bec27489e98ef25a397cfa1774b375d5787509c06659b3671"},
-    {file = "fonttools-4.53.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:da33440b1413bad53a8674393c5d29ce64d8c1a15ef8a77c642ffd900d07bfe1"},
-    {file = "fonttools-4.53.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ff7e5e9bad94e3a70c5cd2fa27f20b9bb9385e10cddab567b85ce5d306ea923"},
-    {file = "fonttools-4.53.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6e7170d675d12eac12ad1a981d90f118c06cf680b42a2d74c6c931e54b50719"},
-    {file = "fonttools-4.53.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bee32ea8765e859670c4447b0817514ca79054463b6b79784b08a8df3a4d78e3"},
-    {file = "fonttools-4.53.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6e08f572625a1ee682115223eabebc4c6a2035a6917eac6f60350aba297ccadb"},
-    {file = "fonttools-4.53.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b21952c092ffd827504de7e66b62aba26fdb5f9d1e435c52477e6486e9d128b2"},
-    {file = "fonttools-4.53.1-cp311-cp311-win32.whl", hash = "sha256:9dfdae43b7996af46ff9da520998a32b105c7f098aeea06b2226b30e74fbba88"},
-    {file = "fonttools-4.53.1-cp311-cp311-win_amd64.whl", hash = "sha256:d4d0096cb1ac7a77b3b41cd78c9b6bc4a400550e21dc7a92f2b5ab53ed74eb02"},
-    {file = "fonttools-4.53.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:d92d3c2a1b39631a6131c2fa25b5406855f97969b068e7e08413325bc0afba58"},
-    {file = "fonttools-4.53.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3b3c8ebafbee8d9002bd8f1195d09ed2bd9ff134ddec37ee8f6a6375e6a4f0e8"},
-    {file = "fonttools-4.53.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32f029c095ad66c425b0ee85553d0dc326d45d7059dbc227330fc29b43e8ba60"},
-    {file = "fonttools-4.53.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10f5e6c3510b79ea27bb1ebfcc67048cde9ec67afa87c7dd7efa5c700491ac7f"},
-    {file = "fonttools-4.53.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f677ce218976496a587ab17140da141557beb91d2a5c1a14212c994093f2eae2"},
-    {file = "fonttools-4.53.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9e6ceba2a01b448e36754983d376064730690401da1dd104ddb543519470a15f"},
-    {file = "fonttools-4.53.1-cp312-cp312-win32.whl", hash = "sha256:791b31ebbc05197d7aa096bbc7bd76d591f05905d2fd908bf103af4488e60670"},
-    {file = "fonttools-4.53.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ed170b5e17da0264b9f6fae86073be3db15fa1bd74061c8331022bca6d09bab"},
-    {file = "fonttools-4.53.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c818c058404eb2bba05e728d38049438afd649e3c409796723dfc17cd3f08749"},
-    {file = "fonttools-4.53.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:651390c3b26b0c7d1f4407cad281ee7a5a85a31a110cbac5269de72a51551ba2"},
-    {file = "fonttools-4.53.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e54f1bba2f655924c1138bbc7fa91abd61f45c68bd65ab5ed985942712864bbb"},
-    {file = "fonttools-4.53.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9cd19cf4fe0595ebdd1d4915882b9440c3a6d30b008f3cc7587c1da7b95be5f"},
-    {file = "fonttools-4.53.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:2af40ae9cdcb204fc1d8f26b190aa16534fcd4f0df756268df674a270eab575d"},
-    {file = "fonttools-4.53.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:35250099b0cfb32d799fb5d6c651220a642fe2e3c7d2560490e6f1d3f9ae9169"},
-    {file = "fonttools-4.53.1-cp38-cp38-win32.whl", hash = "sha256:f08df60fbd8d289152079a65da4e66a447efc1d5d5a4d3f299cdd39e3b2e4a7d"},
-    {file = "fonttools-4.53.1-cp38-cp38-win_amd64.whl", hash = "sha256:7b6b35e52ddc8fb0db562133894e6ef5b4e54e1283dff606fda3eed938c36fc8"},
-    {file = "fonttools-4.53.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:75a157d8d26c06e64ace9df037ee93a4938a4606a38cb7ffaf6635e60e253b7a"},
-    {file = "fonttools-4.53.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4824c198f714ab5559c5be10fd1adf876712aa7989882a4ec887bf1ef3e00e31"},
-    {file = "fonttools-4.53.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:becc5d7cb89c7b7afa8321b6bb3dbee0eec2b57855c90b3e9bf5fb816671fa7c"},
-    {file = "fonttools-4.53.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84ec3fb43befb54be490147b4a922b5314e16372a643004f182babee9f9c3407"},
-    {file = "fonttools-4.53.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:73379d3ffdeecb376640cd8ed03e9d2d0e568c9d1a4e9b16504a834ebadc2dfb"},
-    {file = "fonttools-4.53.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:02569e9a810f9d11f4ae82c391ebc6fb5730d95a0657d24d754ed7763fb2d122"},
-    {file = "fonttools-4.53.1-cp39-cp39-win32.whl", hash = "sha256:aae7bd54187e8bf7fd69f8ab87b2885253d3575163ad4d669a262fe97f0136cb"},
-    {file = "fonttools-4.53.1-cp39-cp39-win_amd64.whl", hash = "sha256:e5b708073ea3d684235648786f5f6153a48dc8762cdfe5563c57e80787c29fbb"},
-    {file = "fonttools-4.53.1-py3-none-any.whl", hash = "sha256:f1f8758a2ad110bd6432203a344269f445a2907dc24ef6bccfd0ac4e14e0d71d"},
-    {file = "fonttools-4.53.1.tar.gz", hash = "sha256:e128778a8e9bc11159ce5447f76766cefbd876f44bd79aff030287254e4752c4"},
+    {file = "fonttools-4.54.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b2957597455a21fc55849cf5094507028b241035e9bf2d98daa006c152553640"},
+    {file = "fonttools-4.54.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:18a043a029994c28638bd40cf0d7dbe8edfbacb6b60f6a5ccdfcc4db98eaa4e4"},
+    {file = "fonttools-4.54.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb1dd36e8612b31f30ae8fa264fdddf1a0c22bab0990c5f97542b86cbf0b77ec"},
+    {file = "fonttools-4.54.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2703efc48b6e88b58249fb6316373e15e5b2e5835a58114954b290faebbd89da"},
+    {file = "fonttools-4.54.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:21a209d7ff42ab567e449ba8f86af7bc5e93e2463bd07cbfae7284057d1552ac"},
+    {file = "fonttools-4.54.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:812d04179b6a99bff3241153c928e1b3db98c76113375ce6b561e93dc749da3f"},
+    {file = "fonttools-4.54.0-cp310-cp310-win32.whl", hash = "sha256:0d15664cbdc059ca1a32ff2a5cb5428ffd47f2e739430d9d11b0b6e2a97f2b8b"},
+    {file = "fonttools-4.54.0-cp310-cp310-win_amd64.whl", hash = "sha256:abc5acdfdb01e2af1de55153f3720376edf4df8bcad84bdc54c08abda2089fd4"},
+    {file = "fonttools-4.54.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:96e7a37190a20063dc6f301665180148ec7671f9b6ef089dba2280a8434adacc"},
+    {file = "fonttools-4.54.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a42e0500944de3abf8723a439c7c94678d14b702808a593d7bfcece4a3ff4479"},
+    {file = "fonttools-4.54.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24160f6df15e01d0edfb64729373950c2869871a611924d50c2e676162dcc42d"},
+    {file = "fonttools-4.54.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3c556e69f66de64b2604d6875d5d1913484f89336d782a4bb89b772648436a3"},
+    {file = "fonttools-4.54.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2ee6664fe61a932f52c499d2e8d72e6c7c6207449e2ec12928ebf80f2580ea31"},
+    {file = "fonttools-4.54.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79bb6834403cbb0f851df7173e8e9adbcfe3bb2e09a472de4c2e8a2667257b47"},
+    {file = "fonttools-4.54.0-cp311-cp311-win32.whl", hash = "sha256:6679b471655f4f6bcdacb2b05bb059fc8d10983870e1a039d101da50562b90ec"},
+    {file = "fonttools-4.54.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d328d8d7414d7a70186a0d5c6fe9eea04b8b019ae070964b0555acfa763bba"},
+    {file = "fonttools-4.54.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:34758e8481a5054e7e203c5e15c41dc3ec67716407bd1f00ebf014fe94f934e3"},
+    {file = "fonttools-4.54.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:49124ff0efd6ded3e320912409527c9f3dae34acf34dcca141961a0c2dee484e"},
+    {file = "fonttools-4.54.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:105b4dbf35bd8aad2c79b8b12ca911a00d7e445a251383a523497e0fb06c4242"},
+    {file = "fonttools-4.54.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b6b613894d8e90093326ab6014c202a7a503e34dfb4a632b2ec78078f406c43"},
+    {file = "fonttools-4.54.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6587da0a397c9ae36b8c7e3febfca8c4563d287f7339d805cd4a9a356a39f6bf"},
+    {file = "fonttools-4.54.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:801bdd3496ec6df3920ae5cf43567208246c944288d2a508985491c9126f4dd9"},
+    {file = "fonttools-4.54.0-cp312-cp312-win32.whl", hash = "sha256:e299ecc34635621b792bf42dcc3be50810dd74c888474e09b47596853a08db56"},
+    {file = "fonttools-4.54.0-cp312-cp312-win_amd64.whl", hash = "sha256:f7b2e35b912235290b5e8df0cab17e3365be887c88588fdd9589e7635e665460"},
+    {file = "fonttools-4.54.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:948fafa5035cf22ed35040c07b7a4ebe9c9d3436401d4d4a4fea19a24bee8fd5"},
+    {file = "fonttools-4.54.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ef61d49d1f724dd8f1bf99328cfbc5e64900f451be0eacfcd15a1e00493779be"},
+    {file = "fonttools-4.54.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d037c0b7d93408584065f5d30cd3a1c533a195d96669de116df3b594f6753b6"},
+    {file = "fonttools-4.54.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dbb7646fd6f6fdf754015cbb50db10cd53770432e56bd6b2e6411fb54a1b83b2"},
+    {file = "fonttools-4.54.0-cp313-cp313-win32.whl", hash = "sha256:66143c6607d85647ef5097c7d3005118288ef6d7607487c10b04549f830eee01"},
+    {file = "fonttools-4.54.0-cp313-cp313-win_amd64.whl", hash = "sha256:f66a6e29a201a4e0ff8a1f33dc90781f018e0dd8caa29d33311110952bdf8285"},
+    {file = "fonttools-4.54.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:eb871afe7bd480d233c0c29a694cbc553743e8af9c8daa9c70284862b35c5e80"},
+    {file = "fonttools-4.54.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4f864d49effec5877c1ea559e2cb01bf6162f066c9013b78e1b31c13c120bee4"},
+    {file = "fonttools-4.54.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e56abc2aad22298bd62f1314940b22f613eb4e9a50c5d9450d50c4c42e4617bf"},
+    {file = "fonttools-4.54.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:633bd642239412115a4d203728980bf57993f1bcd22299c71f0c2ea669b75604"},
+    {file = "fonttools-4.54.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:1170ed2208ace22ebe3bd119cec42fec9d393a133c204d6c7a28f28820c1eced"},
+    {file = "fonttools-4.54.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:59ed3b6fcdfc29e4ffb75d300710bef50379caa639cd8e1b83415f7f1462d6ec"},
+    {file = "fonttools-4.54.0-cp38-cp38-win32.whl", hash = "sha256:c6db5c17464f50ccd1b6d362e54d5e5930e551382c79f36f5f73b2bfd20fc340"},
+    {file = "fonttools-4.54.0-cp38-cp38-win_amd64.whl", hash = "sha256:c4392e878e8e8d14ab7963a5accf25802eb6a9499c40e698c9bf571816026daf"},
+    {file = "fonttools-4.54.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a05cb4ebb638147a11b15eb2fffbe71bbf2df7ec6d6655430a07d97164dddb0"},
+    {file = "fonttools-4.54.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7b80c2e5ce6e69291fe73f7a71f26ae767e53e8c2e4b08826d7c9524ef0ebaad"},
+    {file = "fonttools-4.54.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:627c0e59883fb97be4ec46cb0561f521214f3d8a10ad7f2a4030d3cd38a0a0ab"},
+    {file = "fonttools-4.54.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc4e10d9c7e9ec55431f49f7425bc5c0472f0b25ff56ad57a66d7e503d36e83e"},
+    {file = "fonttools-4.54.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:370a2018eeaeba47742103ac4e3877acfa7819ea64725aa7646f16e1cbab6223"},
+    {file = "fonttools-4.54.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4dc1e6ebff17e2f012d5084058fd89fd66c7fd02ac9960380fab236114a977fb"},
+    {file = "fonttools-4.54.0-cp39-cp39-win32.whl", hash = "sha256:fff3ff4a7e864b98502a15b04f3b9eedd26f8ff3f60be325cd715b9af8e54d05"},
+    {file = "fonttools-4.54.0-cp39-cp39-win_amd64.whl", hash = "sha256:e7e1c173b21d00f336ab0d4edf2ea64e7a8530863bae789d97cd52a4363fbd6f"},
+    {file = "fonttools-4.54.0-py3-none-any.whl", hash = "sha256:351058cd623af4c45490c744e2bbc5671fc78dce95866e92122c9ba6c28ea8b6"},
+    {file = "fonttools-4.54.0.tar.gz", hash = "sha256:9f3482ff1189668fa9f8eafe8ff8541fb154b6f0170f8477889c028eb893c6ee"},
 ]
 
 [package.extras]
@@ -4812,13 +4818,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2024.1"
+version = "2024.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
-    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
 
 [[package]]

--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 import itertools
 import math
+import warnings
 from collections import defaultdict
 from enum import Enum, auto
 from typing import List, Set, Union
@@ -49,6 +50,7 @@ from qat.purr.compiler.instructions import (
 )
 from qat.purr.utils.logger import get_default_logger
 
+warnings.simplefilter("always", DeprecationWarning)
 log = get_default_logger()
 
 
@@ -697,6 +699,12 @@ class QuantumInstructionBuilder(InstructionBuilder):
         previous_measure_block = self._find_previous_measurement_block()
 
         if isinstance(previous_measure_block, list):
+            warnings.warn(
+                "Use of legacy measurement block recognition is deprecated. "
+                "Please use the 'MeasureBlock' type instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             new_measure_block, acquire_instruction = self._generate_legacy_measure_block(
                 qubit, mode, entangled_qubits, output_variable
             )

--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -581,6 +581,20 @@ class QuantumInstructionBuilder(InstructionBuilder):
             PhaseReset(entangled_qubits),
         ], acquire_instruction
 
+    def _generate_measure_block(
+        self,
+        qubit: Qubit,
+        mode: AcquireMode,
+        entangled_qubits: List[Qubit],
+        output_variable: str = None,
+    ):
+        measure_block = MeasureBlock(
+            qubit, mode, output_variable, entangled_qubits, self.existing_names
+        )
+        acquire_instruction = measure_block.get_acquires(qubit)[0]
+
+        return measure_block, acquire_instruction
+
     def _find_previous_measurement_block(
         self,
         mblock_types: List[Instruction] = [Acquire, MeasurePulse],
@@ -696,11 +710,10 @@ class QuantumInstructionBuilder(InstructionBuilder):
             )
             acquire_instruction = previous_measure_block.get_acquires(qubit)[0]
         else:
-            measure_block = MeasureBlock(
-                qubit, mode, output_variable, entangled_qubits, self.existing_names
+            new_measure_block, acquire_instruction = self._generate_measure_block(
+                qubit, mode, entangled_qubits, output_variable
             )
-            self.add(measure_block)
-            acquire_instruction = measure_block.get_acquires(qubit)[0]
+            self.add(new_measure_block)
 
         return FluidBuilderWrapper(self, acquire_instruction)
 

--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -133,7 +133,7 @@ class InstructionBuilder:
 
             inst.name = new_name
 
-    def merge_builder(self, other_builder: "InstructionBuilder"):
+    def merge_builder(self, other_builder: "InstructionBuilder", index: int = None):
         """
         Merge this builder into the current instance. Checks for label name clashes and
         resolves them if any are found.
@@ -147,7 +147,9 @@ class InstructionBuilder:
             )
             other_builder._fix_clashing_label_names(name_clashes, self.existing_names)
 
-        self.add(other_builder._instructions)
+        index = index or len(self._instructions)
+        self.insert(other_builder._instructions, index)
+        return index + len(other_builder._instructions)
 
     def add(
         self,
@@ -162,32 +164,45 @@ class InstructionBuilder:
         accessing the instructions list directly as it deals with nested builders and
         merging.
         """
+        return self.insert(components, len(self._instructions))
+
+    def insert(
+        self,
+        components: Union[
+            "InstructionBuilder",
+            Instruction,
+            List[Union["InstructionBuilder", Instruction]],
+        ],
+        index: int,
+    ):
+        """
+        Adds an instruction to this builder. All methods should use this instead of
+        accessing the instructions list directly as it deals with nested builders and
+        merging.
+        """
         if components is None:
             return self
 
         if not isinstance(components, List):
             components = [components]
 
-        inst_list = []
         for component in components:
             if isinstance(component, InstructionBuilder):
-                self.merge_builder(component)
+                index = self.merge_builder(component)
             else:
-                inst_list.append(component)
-
-        for inst in inst_list:
-            # Naive entanglement checker for syncronization.
-            if isinstance(inst, CrossResonancePulse):
-                ent_qubits = self._get_entangled_qubits(inst)
-                for qubit in ent_qubits:
-                    self._entanglement_map[qubit].update(ent_qubits)
-                for qubit in self.model.qubits:
-                    # entanglement is transitive, if A<>B and B<>C then C<>A
-                    tmp = set()
-                    for entangled in self._entanglement_map[qubit]:
-                        tmp.update(self._entanglement_map[entangled])
-                    self._entanglement_map[qubit].update(tmp)
-            self._instructions.append(inst)
+                # Naive entanglement checker for syncronization.
+                if isinstance(component, CrossResonancePulse):
+                    ent_qubits = self._get_entangled_qubits(component)
+                    for qubit in ent_qubits:
+                        self._entanglement_map[qubit].update(ent_qubits)
+                    for qubit in self.model.qubits:
+                        # entanglement is transitive, if A<>B and B<>C then C<>A
+                        tmp = set()
+                        for entangled in self._entanglement_map[qubit]:
+                            tmp.update(self._entanglement_map[entangled])
+                        self._entanglement_map[qubit].update(tmp)
+                self._instructions.insert(index, component)
+                index += 1
         return self
 
     def _get_entangled_qubits(self, inst):
@@ -518,8 +533,110 @@ class QuantumInstructionBuilder(InstructionBuilder):
 
         return results
 
+    def _generate_measure_block(
+        self, qubit: Qubit, mode: AcquireMode, output_variable: str = None
+    ):
+        measure_channel = qubit.get_measure_channel()
+        acquire_channel = qubit.get_acquire_channel()
+        weights = (
+            qubit.measure_acquire.get("weights", None)
+            if qubit.measure_acquire.get("use_weights", False)
+            else None
+        )
+        # Naive entanglement checker to assure all entangled qubits are sync before a
+        # measurement is done on any of them.
+        entangled_qubits = list(self._entanglement_map.get(qubit, []))
+
+        measure_instruction = MeasurePulse(measure_channel, **qubit.pulse_measure)
+        acquire_instruction = Acquire(
+            acquire_channel,
+            (
+                qubit.pulse_measure["width"]
+                if qubit.measure_acquire["sync"]
+                else qubit.measure_acquire["width"]
+            ),
+            mode,
+            output_variable,
+            self.existing_names,
+            qubit.measure_acquire["delay"],
+            weights,
+        )
+
+        return [
+            Synchronize(entangled_qubits),
+            measure_instruction,
+            acquire_instruction,
+            Synchronize(qubit),
+            PhaseReset(entangled_qubits),
+        ], acquire_instruction
+
+    def _find_previous_measurement_block(
+        self,
+        mblock_types: List[Instruction] = [Acquire, MeasurePulse],
+        optional_block_types: List[Instruction] = [Synchronize, PhaseReset],
+    ):
+        # List of node types that a measurement can be made up of.
+        mblock_types_cycle = itertools.cycle(mblock_types)
+
+        # Look at the instructions immediately before this measure, and try to find a
+        # set of instructions that look exactly like a measure selection. It's a little
+        # bit loose with matching, but if it sees a measure followed by an acquire,
+        # surrounded by syncs and post-processing, it'll accept that block as a
+        # 'measurement'.
+        current_type = next(mblock_types_cycle)
+        previous_measure_block = []
+        instructions = reversed(self._instructions)
+
+        for inst in instructions:
+            if not isinstance(inst, QuantumInstruction) or isinstance(inst, PostProcessing):
+                continue
+
+            if not isinstance(inst, (*optional_block_types, current_type)):
+                current_type = next(mblock_types_cycle)
+                if not isinstance(inst, (*optional_block_types, current_type)):
+                    break
+
+            previous_measure_block.insert(0, inst)
+
+        return previous_measure_block
+
+    def _join_measure_blocks(self, previous_measure_block, new_measure_block):
+        # If we detect a full measure block before us, merge it together if we're
+        # entangled and/or can do it validly.
+        pre_syncs = [val for val in previous_measure_block if isinstance(val, Synchronize)]
+        new_syncs = [val for val in new_measure_block if isinstance(val, Synchronize)]
+        pre_phase_resets = [
+            val for val in previous_measure_block if isinstance(val, PhaseReset)
+        ]
+        new_phase_resets = [val for val in new_measure_block if isinstance(val, PhaseReset)]
+        full_measure_block = set([val.__class__ for val in previous_measure_block]) == set(
+            [val.__class__ for val in new_measure_block]
+        )
+        if full_measure_block and len(pre_syncs) >= 2 and len(pre_phase_resets) >= 1:
+            # Merge the first and last sync with the new.
+            pre_syncs[0] += new_syncs[0]
+            pre_syncs[-1] += new_syncs[-1]
+
+            # reset all qubits
+            pre_phase_resets[-1] += new_phase_resets[-1]
+
+            # Add in our current changes.
+            self.insert(
+                [
+                    val
+                    for val in new_measure_block
+                    if isinstance(val, (MeasurePulse, Acquire))
+                ],
+                index=self._instructions.index(pre_syncs[-1]),
+            )
+        else:
+            self.add(new_measure_block)
+
     def measure(
-        self, qubit: Qubit, axis: ProcessAxis = None, output_variable: str = None
+        self,
+        qubit: Qubit,
+        axis: ProcessAxis = None,
+        output_variable: str = None,
     ) -> "QuantumInstructionBuilder":
         """
         Adds a measure instruction. Important note: this only adds the instruction, not
@@ -537,105 +654,16 @@ class QuantumInstructionBuilder(InstructionBuilder):
         else:
             raise ValueError(f"Wrong measure axis '{str(axis)}'!")
 
-        # Naive entanglement checker to assure all entangled qubits are sync before a
-        # measurement is done on any of them.
-        entangled_qubits = list(self._entanglement_map.get(qubit, []))
-
-        # List of node types that a measurement can be made up of.
-        mblock_types = [Acquire, MeasurePulse]
-        mblock_types_cycle = itertools.cycle(mblock_types)
-        optional_block_types = [PostProcessing, Synchronize, PhaseReset]
-
-        # Look at the instructions immediately before this measure, and try to find a
-        # set of instructions that look exactly like a measure selection. It's a little
-        # bit loose with matching, but if it sees a measure followed by an acquire,
-        # surrounded by syncs and post-processing, it'll accept that block as a
-        # 'measurement'.
-        current_type = next(mblock_types_cycle)
-        previous_measure_block = []
-        for inst in reversed(self._instructions):
-            # We skip classic instructions since they have no relevance.
-            if not isinstance(inst, QuantumInstruction):
-                continue
-
-            if not isinstance(inst, (*optional_block_types, current_type)):
-                current_type = next(mblock_types_cycle)
-                if not isinstance(inst, (*optional_block_types, current_type)):
-                    break
-
-            previous_measure_block.append(inst)
-
-        measure_channel = qubit.get_measure_channel()
-        acquire_channel = qubit.get_acquire_channel()
-        weights = (
-            qubit.measure_acquire.get("weights", None)
-            if qubit.measure_acquire.get("use_weights", False)
-            else None
-        )
-        acquire_instruction = Acquire(
-            acquire_channel,
-            (
-                qubit.pulse_measure["width"]
-                if qubit.measure_acquire["sync"]
-                else qubit.measure_acquire["width"]
-            ),
-            mode,
-            output_variable,
-            self.existing_names,
-            qubit.measure_acquire["delay"],
-            weights,
+        new_measure_block, acquire_instruction = self._generate_measure_block(
+            qubit, mode, output_variable
         )
 
-        # If we detect a full measure block before us, merge it together if we're
-        # entangled and/or can do it validly.
-        syncs = [val for val in previous_measure_block if isinstance(val, Synchronize)]
-        phase_resets = [
-            val for val in previous_measure_block if isinstance(val, PhaseReset)
-        ]
-        full_measure_block = set([val.__class__ for val in previous_measure_block]) == set(
-            mblock_types + optional_block_types
-        )
-        if full_measure_block and len(syncs) >= 2 and len(phase_resets) >= 1:
-            # Find the pre-measure sync in the preceeding measure block and merge our
-            # values into it.
-            syncs[-1].add_channels(entangled_qubits)
+        previous_measure_block = self._find_previous_measurement_block()
 
-            # Find the post-measure sync, merge with ours, then remove it.
-            final_syncronize = syncs[0] + qubit
-            self._instructions.remove(syncs[0])
-            # reset all qubits
-            final_phase_reset = phase_resets[0] + entangled_qubits
-            self._instructions.remove(phase_resets[0])
-
-            # Add in our current changes.
-            self.add(
-                [
-                    MeasurePulse(measure_channel, **qubit.pulse_measure),
-                    acquire_instruction,
-                    final_syncronize,
-                    final_phase_reset,
-                ]
-            )
-
-            # Move all post-processing until after our newly-shifted syncronize block.
-            # Order matters here.
-            for pp in [
-                val
-                for val in reversed(previous_measure_block)
-                if isinstance(val, PostProcessing)
-            ]:
-                self._instructions.remove(pp)
-                self.add(pp)
+        if len(previous_measure_block) > 0:
+            self._join_measure_blocks(previous_measure_block, new_measure_block)
         else:
-            self.add(
-                [
-                    Synchronize(entangled_qubits),
-                    MeasurePulse(measure_channel, **qubit.pulse_measure),
-                    acquire_instruction,
-                    Synchronize(qubit),
-                    PhaseReset(entangled_qubits),
-                ]
-            )
+            self.add(new_measure_block)
 
         return FluidBuilderWrapper(self, acquire_instruction)
 

--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -184,7 +184,7 @@ class InstructionBuilder:
         index: int,
     ):
         """
-        Adds an instruction to this builder. All methods should use this instead of
+        Inserts an instruction into this builder. All methods should use this instead of
         accessing the instructions list directly as it deals with nested builders and
         merging.
         """

--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -143,10 +143,15 @@ class InstructionBuilder:
 
             inst.name = new_name
 
-    def merge_builder(self, other_builder: "InstructionBuilder", index: int = None):
+    def merge_builder(self, other_builder: "InstructionBuilder", index: int = None) -> int:
         """
         Merge this builder into the current instance. Checks for label name clashes and
         resolves them if any are found.
+
+        :param index: index of self at which to insert the instructions of `other_builder`.
+        :type index: int
+        :returns: the next index to use for additional inserts.
+        :rtype: int
         """
         name_clashes = other_builder.existing_names.intersection(self.existing_names)
         self.existing_names.update(other_builder.existing_names)
@@ -186,9 +191,9 @@ class InstructionBuilder:
         index: int,
     ):
         """
-        Inserts an instruction into this builder. All methods should use this instead of
-        accessing the instructions list directly as it deals with nested builders and
-        merging.
+        Inserts one or more instruction(s) into this builder, starting at index. All methods
+        should use this instead of accessing the instructions list directly as it deals with
+        nested builders and merging.
         """
         if components is None:
             return self

--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -589,6 +589,7 @@ class QuantumInstructionBuilder(InstructionBuilder):
         mode: AcquireMode,
         entangled_qubits: List[Qubit],
         output_variable: str = None,
+        **kwargs,
     ):
         measure_block = MeasureBlock(
             qubit, mode, output_variable, entangled_qubits, self.existing_names
@@ -678,6 +679,7 @@ class QuantumInstructionBuilder(InstructionBuilder):
         qubit: Qubit,
         axis: ProcessAxis = None,
         output_variable: str = None,
+        **kwargs,
     ) -> "QuantumInstructionBuilder":
         """
         Adds a measure instruction. Important note: this only adds the instruction, not
@@ -719,7 +721,7 @@ class QuantumInstructionBuilder(InstructionBuilder):
             acquire_instruction = previous_measure_block.get_acquires(qubit)[0]
         else:
             new_measure_block, acquire_instruction = self._generate_measure_block(
-                qubit, mode, entangled_qubits, output_variable
+                qubit, mode, entangled_qubits, output_variable, **kwargs
             )
             self.add(new_measure_block)
 

--- a/src/qat/purr/compiler/config.py
+++ b/src/qat/purr/compiler/config.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 import warnings
 
-warnings.simplefilter("default", DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 warnings.warn(
     "module 'qat.purr.compiler.config' is deprecated, please use "
     "'compiler_config.serialiser instead.'",
     DeprecationWarning,
+    stacklevel=2,
 )
 
 from compiler_config.config import *  # fmt: skip

--- a/src/qat/purr/compiler/emitter.py
+++ b/src/qat/purr/compiler/emitter.py
@@ -74,7 +74,7 @@ class QatFile:
         for instruction in self.instructions:
             if (
                 isinstance(instruction, PostProcessing)
-                and instruction.acquire.output_variable == target_var
+                and instruction.output_variable == target_var
             ):
                 results.append(instruction)
 

--- a/src/qat/purr/compiler/instructions.py
+++ b/src/qat/purr/compiler/instructions.py
@@ -203,6 +203,11 @@ class Synchronize(QuantumInstruction):
         new_sync.add_channels(other_targets)
         return new_sync
 
+    def __iadd__(self, other):
+        other_targets = other.quantum_targets if isinstance(other, Synchronize) else other
+        self.add_channels(other_targets)
+        return self
+
     def __repr__(self):
         return f"sync {','.join(name.id for name in self.quantum_targets)}"
 
@@ -470,6 +475,11 @@ class PhaseReset(QuantumInstruction):
         new_reset = PhaseReset(self.quantum_targets)
         new_reset.add_channels(other_targets)
         return new_reset
+
+    def __iadd__(self, other):
+        other_targets = other.quantum_targets if isinstance(other, PhaseReset) else other
+        self.add_channels(other_targets)
+        return self
 
     def __repr__(self):
         return f"phase reset {','.join(name.id for name in self.quantum_targets)}"

--- a/src/qat/purr/compiler/instructions.py
+++ b/src/qat/purr/compiler/instructions.py
@@ -826,14 +826,16 @@ class MeasureBlock(QuantumInstructionBlock):
             meas, acq = self._generate_measure_acquire(
                 target, mode, output_variable, existing_names
             )
-            self._duration = max(self._duration, meas.duration, acq.delay + acq.duration)
+            duration = max(meas.duration, acq.delay + acq.duration)
             self._target_dict[target.full_id()] = {
                 "target": target,
                 "mode": mode,
                 "output_variable": output_variable,
                 "measure": meas,
                 "acquire": acq,
+                "duration": duration,
             }
+            self._duration = max(self._duration, duration)
         self._entangled_qubits.update(
             self._validate_targets(entangled_qubits, (Qubit))
             if entangled_qubits is not None

--- a/src/qat/purr/compiler/instructions.py
+++ b/src/qat/purr/compiler/instructions.py
@@ -760,18 +760,18 @@ class InstructionBlock:
 
     instructions: List[Instruction]
 
-    def _validate_targets(self, targets, valid_types):
-        if targets is None:
-            targets = []
-        elif not isinstance(targets, List):
-            targets = [targets]
+    def _validate_types(self, items, valid_types, label="targets"):
+        if items is None:
+            items = []
+        elif not isinstance(items, List):
+            items = [items]
 
-        invalid_targets = [val for val in targets if not isinstance(val, valid_types)]
-        if any(invalid_targets):
-            invalid_targets_str = ",".join([str(val) for val in invalid_targets])
-            raise ValueError(f"Invalid targets for {type(self)}: {invalid_targets_str}")
+        invalid_items = [item for item in items if not isinstance(item, valid_types)]
+        if any(invalid_items):
+            invalid_items_str = ",".join([str(item) for item in invalid_items])
+            raise ValueError(f"Invalid {label} for {type(self)}: {invalid_items_str}")
 
-        return targets
+        return items
 
 
 class QuantumInstructionBlock(InstructionBlock):
@@ -807,7 +807,7 @@ class MeasureBlock(QuantumInstructionBlock):
         entangled_qubits: List[Qubit] = None,
         existing_names: Set[str] = None,
     ):
-        targets = self._validate_targets(targets, (Qubit))
+        targets = self._validate_types(targets, (Qubit))
         if len((duplicates := [t for t in targets if t in self.quantum_targets])) > 0:
             raise ValueError(
                 "Target can only be measured once in a 'MeasureBlock'. "
@@ -837,7 +837,7 @@ class MeasureBlock(QuantumInstructionBlock):
             }
             self._duration = max(self._duration, duration)
         self._entangled_qubits.update(
-            self._validate_targets(entangled_qubits, (Qubit))
+            self._validate_types(entangled_qubits, (Qubit))
             if entangled_qubits is not None
             else targets
         )

--- a/src/qat/purr/compiler/instructions.py
+++ b/src/qat/purr/compiler/instructions.py
@@ -755,6 +755,11 @@ def calculate_duration(instruction, return_samples: bool = True):
 
 
 class InstructionBlock:
+    """An Instruction grouping type. Allows working with blocks of Instructions as a
+    unit."""
+
+    instructions: List[Instruction]
+
     def _validate_targets(self, targets, valid_types):
         if targets is None:
             targets = []
@@ -770,12 +775,16 @@ class InstructionBlock:
 
 
 class QuantumInstructionBlock(InstructionBlock):
+    """Allows working with blocks of QuantumInstructions as a unit."""
+
     quantum_targets: List[QuantumComponent]
     instructions: List[QuantumInstruction]
     duration: float
 
 
 class MeasureBlock(QuantumInstructionBlock):
+    """Groups multiple qubit measurements together."""
+
     def __init__(
         self,
         targets: Union[Qubit, List[Qubit]],
@@ -851,7 +860,7 @@ class MeasureBlock(QuantumInstructionBlock):
         return f"Measure {', '.join(target_strings)}"
 
     @property
-    def instructions(self):
+    def instructions(self) -> List[QuantumInstruction]:
         instructions = [Synchronize(list(self._entangled_qubits))]
         for _, values in self._target_dict.items():
             instructions.extend([values["measure"], values["acquire"]])

--- a/src/qat/purr/utils/serializer.py
+++ b/src/qat/purr/utils/serializer.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 import warnings
 
-warnings.simplefilter("default", DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 warnings.warn(
     "module 'qat.purr.utils.serializer' is deprecated, please use "
     "'compiler_config.serialiser instead.'",
     DeprecationWarning,
+    stacklevel=2,
 )
 
 from compiler_config.serialiser import *  # fmt: skip


### PR DESCRIPTION
Splitting `builder.measure()` into sub-methods and introducing `InstructionBlock` types to simplify the recognition and fusing of adjacent measures.