### PR TITLE
Add flag for bypassing pulse duration limits.

### DIFF
--- a/src/qat/purr/qatconfig.py
+++ b/src/qat/purr/qatconfig.py
@@ -47,10 +47,6 @@ class QatConfig(BaseSettings):
             )
         return DISABLE_PULSE_DURATION_LIMITS
 
-    @field_validator("MAX_REPEATS_LIMIT")
-    def check_max_repeats_limit(cls, MAX_REPEATS_LIMIT):
-        return MAX_REPEATS_LIMIT or 100_000
-
 
 qatconfig = QatConfig()
 

--- a/src/qat/purr/qatconfig.py
+++ b/src/qat/purr/qatconfig.py
@@ -1,7 +1,11 @@
 from typing import Union
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from qat.purr.utils.logger import get_default_logger
+
+log = get_default_logger()
 
 
 class QatConfig(BaseSettings, validate_assignment=True):
@@ -31,6 +35,16 @@ class QatConfig(BaseSettings, validate_assignment=True):
     model_config = SettingsConfigDict(env_prefix="QAT_")
     MAX_REPEATS_LIMIT: Union[None, int] = Field(gt=0, default=100_000)
     """Max number of repeats / shots to be performed in a single job."""
+    DISABLE_PULSE_DURATION_LIMITS: bool = False
+    """Flag to disable the lower and upper pulse duration limits. 
+    Only needs to be set to True for calibration purposes."""
+
+    @field_validator("DISABLE_PULSE_DURATION_LIMITS")
+    def check_disable_pulse_duration_limits(cls, DISABLE_PULSE_DURATION_LIMITS):
+        if DISABLE_PULSE_DURATION_LIMITS:
+            log.warning(
+                "Disabled check for pulse duration limits, which should ideally only be used for calibration purposes."
+            )
 
 
 qatconfig = QatConfig()

--- a/src/qat/purr/qatconfig.py
+++ b/src/qat/purr/qatconfig.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -8,7 +8,7 @@ from qat.purr.utils.logger import get_default_logger
 log = get_default_logger()
 
 
-class QatConfig(BaseSettings, validate_assignment=True):
+class QatConfig(BaseSettings):
     """
     Full settings for a single job. Allows environment variables to be overridden by direct assignment.
 
@@ -32,8 +32,8 @@ class QatConfig(BaseSettings, validate_assignment=True):
     Input should be a valid integer, got a number with a fractional part
     """
 
-    model_config = SettingsConfigDict(env_prefix="QAT_")
-    MAX_REPEATS_LIMIT: Union[None, int] = Field(gt=0, default=100_000)
+    model_config = SettingsConfigDict(env_prefix="QAT_", validate_assignment=True)
+    MAX_REPEATS_LIMIT: Optional[int] = Field(gt=0, default=100_000)
     """Max number of repeats / shots to be performed in a single job."""
     DISABLE_PULSE_DURATION_LIMITS: bool = False
     """Flag to disable the lower and upper pulse duration limits. 
@@ -45,6 +45,11 @@ class QatConfig(BaseSettings, validate_assignment=True):
             log.warning(
                 "Disabled check for pulse duration limits, which should ideally only be used for calibration purposes."
             )
+        return DISABLE_PULSE_DURATION_LIMITS
+
+    @field_validator("MAX_REPEATS_LIMIT")
+    def check_max_repeats_limit(cls, MAX_REPEATS_LIMIT):
+        return MAX_REPEATS_LIMIT or 100_000
 
 
 qatconfig = QatConfig()

--- a/tests/qat/test_qatconfig.py
+++ b/tests/qat/test_qatconfig.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from qat import qatconfig
 from qat.purr.qatconfig import QatConfig
+from qat.purr.utils.logger import LoggerLevel
 
 MAX_REPEATS_LIMIT = 100_000  # Default value for qatconfig.MAX_REPEATS_LIMIT.
 
@@ -45,11 +46,18 @@ def test_change_max_repeats_limit(repeats_limit):
 
 @pytest.mark.parametrize("disable_pulse_duration_limits", [False, True])
 def test_change_disable_pulse_duration_limits(disable_pulse_duration_limits):
-    print(disable_pulse_duration_limits)
     qatconfig.__init__()  # Reload settings.
     # Test direct change of repeats limit.
     qatconfig.DISABLE_PULSE_DURATION_LIMITS = disable_pulse_duration_limits
     assert qatconfig.DISABLE_PULSE_DURATION_LIMITS == disable_pulse_duration_limits
+
+
+def test_disable_pulse_duration_limits_throws_warning(caplog):
+    qatconfig.__init__()  # Reload settings.
+    # Capture if warnings are sent to logger.
+    with caplog.at_level(LoggerLevel.WARNING.value):
+        qatconfig.DISABLE_PULSE_DURATION_LIMITS = True
+        assert "Disabled check for pulse duration limits" in caplog.text
 
 
 @pytest.mark.parametrize("repeats_limit", [10_000, 16_874, 50_000, 100_000])

--- a/tests/qat/test_qatconfig.py
+++ b/tests/qat/test_qatconfig.py
@@ -17,6 +17,15 @@ def test_qatconfig_invalid_assignment(invalid_argument):
         qatconfig.MAX_REPEATS_LIMIT = invalid_argument
 
 
+def test_default_disable_pulse_duration_limits(monkeypatch):
+    monkeypatch.delenv("QAT_DISABLE_PULSE_DURATION_LIMITS", raising=False)
+    newconfig = QatConfig()
+    assert (
+        isinstance(newconfig.DISABLE_PULSE_DURATION_LIMITS, bool)
+        and newconfig.DISABLE_PULSE_DURATION_LIMITS == False
+    )
+
+
 def test_default_repeats_limit(monkeypatch):
     monkeypatch.delenv("QAT_MAX_REPEATS_LIMIT", raising=False)
     newconfig = QatConfig()
@@ -34,13 +43,21 @@ def test_change_max_repeats_limit(repeats_limit):
     assert qatconfig.MAX_REPEATS_LIMIT == repeats_limit
 
 
-@pytest.mark.parametrize("repeats_limit", [None, 10_000, 16_874, 50_000, 100_000])
-def test_change_env_max_repeats_limit(monkeypatch, repeats_limit):
-    NEW_LIMIT = 15_321
-    monkeypatch.setenv("QAT_MAX_REPEATS_LIMIT", str(NEW_LIMIT))
+@pytest.mark.parametrize("disable_pulse_duration_limits", [False, True])
+def test_change_disable_pulse_duration_limits(disable_pulse_duration_limits):
+    print(disable_pulse_duration_limits)
+    qatconfig.__init__()  # Reload settings.
+    # Test direct change of repeats limit.
+    qatconfig.DISABLE_PULSE_DURATION_LIMITS = disable_pulse_duration_limits
+    assert qatconfig.DISABLE_PULSE_DURATION_LIMITS == disable_pulse_duration_limits
+
+
+@pytest.mark.parametrize("repeats_limit", [10_000, 16_874, 50_000, 100_000])
+def test_change_env_variables(monkeypatch, repeats_limit):
+    monkeypatch.setenv("QAT_MAX_REPEATS_LIMIT", str(repeats_limit))
     newconfig = QatConfig()
     assert (
-        newconfig.MAX_REPEATS_LIMIT == NEW_LIMIT
+        newconfig.MAX_REPEATS_LIMIT == repeats_limit
     )  # New instances of QatConfig should have the updated env variable.
     assert (
         qatconfig.MAX_REPEATS_LIMIT == MAX_REPEATS_LIMIT


### PR DESCRIPTION
This PR provides patch that introduces a "system"-wide flag to disable pulse duration checks.