### PR TITLE
Extending qiskit simulator capabilities

### DIFF
--- a/src/qat/purr/backends/qiskit_simulator.py
+++ b/src/qat/purr/backends/qiskit_simulator.py
@@ -344,7 +344,7 @@ class QiskitEngine(InstructionExecutionEngine):
                 task_results[creg] = creg_result
         else:
             task_results = trimmed
-        
+
         return (
             (task_results, results.results[0].metadata)
             if qiskitconfig.ENABLE_METADATA

--- a/src/qat/purr/backends/qiskit_simulator.py
+++ b/src/qat/purr/backends/qiskit_simulator.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Oxford Quantum Circuits Ltd
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from compiler_config.config import ErrorMitigationConfig, ResultsFormatting
@@ -11,6 +11,7 @@ from qiskit.transpiler.passes import CheckMap
 from qiskit_aer import AerSimulator
 from qiskit_aer.backends.backendconfiguration import AerBackendConfiguration
 
+from qat import qatconfig
 from qat.purr.backends.echo import (
     Connectivity,
     add_direction_couplings_to_hardware,
@@ -33,6 +34,7 @@ from qat.purr.compiler.runtime import QuantumRuntime
 from qat.purr.utils.logger import get_default_logger
 
 log = get_default_logger()
+qiskitconfig = qatconfig.SIMULATION.QISKIT
 
 
 def get_default_qiskit_hardware(
@@ -41,6 +43,12 @@ def get_default_qiskit_hardware(
     strict_placement=True,
     connectivity: Optional[Union[Connectivity, List[Tuple[int, int]]]] = None,
 ) -> "QiskitHardwareModel":
+    """
+    Creates a hardware model compatible with the Qiskit simulator.
+
+    If `strict_placement=True`, circuits can only be executed when circuit
+    intructions act on adjacent qubits in the coupling map.
+    """
     model = QiskitHardwareModel(qubit_count, noise_model)
     model.strict_placement = strict_placement
 
@@ -229,7 +237,27 @@ class QiskitEngine(InstructionExecutionEngine):
     def run_calibrations(self, qubits_to_calibrate=None):
         pass
 
-    def execute(self, builder: QiskitBuilder) -> Dict[str, Any]:
+    def _run_simulator(self, builder, aer_config, method, coupling_map):
+        qasm_sim = AerSimulator(
+            aer_config,
+            noise_model=builder.model.noise_model,
+            method=method,
+            **qiskitconfig.OPTIONS,
+        )
+        job = qasm_sim.run(
+            transpile(builder.circuit, qasm_sim, coupling_map=coupling_map),
+            shots=builder.shot_count,
+        )
+        return job.result()
+
+    def execute(self, builder: QiskitBuilder):
+        """
+        Execute a circuit using Qiskit's AerSimulator as a backend. Options for the
+        simulator can be provided using qatconfig.SIMULATION.QISKIT.
+
+        For more information, see:
+        https://docs.quantum.ibm.com/api/qiskit/0.37/qiskit.providers.aer.AerSimulator
+        """
         if not isinstance(builder, QiskitBuilder):
             raise ValueError(
                 "Contravariance is not possible with QiskitEngine. "
@@ -253,14 +281,30 @@ class QiskitEngine(InstructionExecutionEngine):
             AerSimulator._DEFAULT_CONFIGURATION | {"open_pulse": False}
         )
         aer_config.n_qubits = self.model.qubit_count
-        qasm_sim = AerSimulator(aer_config, noise_model=builder.model.noise_model)
 
+        # AerSimulator can call a range of backends. We allow these to be choosen, along with
+        # any relevant arguments.
         try:
-            job = qasm_sim.run(
-                transpile(circuit, qasm_sim, coupling_map=coupling_map),
-                shots=builder.shot_count,
-            )
-            results = job.result()
+            # Determine the sequence of backends to try
+            method = qiskitconfig.METHOD
+            seq = qiskitconfig.FALLBACK_SEQUENCE
+            if method in seq:
+                seq.remove(method)
+            seq.insert(0, method)
+
+            # Run the simulator
+            results = {}
+            for method in seq:
+                results = self._run_simulator(
+                    builder,
+                    aer_config,
+                    method,
+                    coupling_map,
+                )
+
+                if results.results[0].success:
+                    break
+                log.warning(f"AerSimulator simulation with method {method} failed.")
             distribution = results.get_counts(circuit)
         except QiskitError as e:
             raise ValueError(f"QiskitError while running Qiskit circuit: {str(e)}")
@@ -298,10 +342,14 @@ class QiskitEngine(InstructionExecutionEngine):
                     else:
                         creg_result[new_key] = value
                 task_results[creg] = creg_result
-
-            return task_results
         else:
-            return trimmed
+            task_results = trimmed
+        
+        return (
+            (task_results, results.results[0].metadata)
+            if qiskitconfig.ENABLE_METADATA
+            else task_results
+        )
 
     def optimize(self, instructions: List[Instruction]) -> List[Instruction]:
         log.info("No optimize implemented for QiskitEngine")
@@ -357,22 +405,29 @@ class QiskitRuntime(QuantumRuntime):
         repeats: int = None,
         error_mitigation: ErrorMitigationConfig = None,
     ):
+        """
+        Execute a circuit using Qiskit's AerSimulator as a backend. Options for the
+        simulator can be provided using qatconfig.SIMULATION.QISKIT.
+
+        For more information, see:
+        https://docs.quantum.ibm.com/api/qiskit/0.37/qiskit.providers.aer.AerSimulator
+        """
         if not isinstance(builder, QiskitBuilder):
             raise ValueError("Wrong builder type passed to QASM runtime.")
-
-        # TODO - add error_mitigation for Qasm sim
         results = self.engine.execute(builder)
+        if qiskitconfig.ENABLE_METADATA:
+            (results, metadata) = results
         results = self._apply_error_mitigation(
             results, builder.instructions, error_mitigation
         )
 
         if all([is_generated_name(k) for k in results.keys()]):
             if len(results) == 1:
-                return list(results.values())[0]
+                results = list(results.values())[0]
             else:
                 squashed_results = list(results.values())
                 if all(isinstance(val, np.ndarray) for val in squashed_results):
-                    return np.array(squashed_results)
-                return squashed_results
-        else:
-            return results
+                    results = np.array(squashed_results)
+                else:
+                    results = squashed_results
+        return (results, metadata) if qiskitconfig.ENABLE_METADATA else results

--- a/src/qat/purr/qatconfig.py
+++ b/src/qat/purr/qatconfig.py
@@ -1,11 +1,45 @@
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from qiskit_aer import AerSimulator
 
 from qat.purr.utils.logger import get_default_logger
 
 log = get_default_logger()
+
+
+class QiskitSimulationConfig(BaseModel):
+    """
+    The default settings for the Qiskit Simulator, including overridden MPS settings.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+    allowed_methods: type = Literal[AerSimulator().available_methods()]
+    METHOD: allowed_methods = "automatic"
+    """The simulation method to use."""
+    FALLBACK_SEQUENCE: list[allowed_methods] = ["automatic", "matrix_product_state"]
+    """If the simulation fails, specify a fallback sequence of methods to call."""
+    OPTIONS: dict = {
+        "matrix_product_state_max_bond_dimension": 128,
+        "matrix_product_state_truncation_threshold": 1e-12,
+    }
+    """
+    Specify the options for a chosen AerSimulator backend. See
+    https://docs.quantum.ibm.com/api/qiskit/0.37/qiskit.providers.aer.AerSimulator
+    for options you can provide.
+    """
+    ENABLE_METADATA: bool = False
+    """Returns the AerSimulator metadata if enabled."""
+
+
+class QatSimulationConfig(BaseModel):
+    """
+    The default settings for QATs simulation backends.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+    QISKIT: QiskitSimulationConfig = QiskitSimulationConfig()
 
 
 class QatConfig(BaseSettings):
@@ -32,12 +66,17 @@ class QatConfig(BaseSettings):
     Input should be a valid integer, got a number with a fractional part
     """
 
-    model_config = SettingsConfigDict(env_prefix="QAT_", validate_assignment=True)
+    model_config = SettingsConfigDict(
+        env_prefix="QAT_", env_nested_delimiter="_", validate_assignment=True
+    )
     MAX_REPEATS_LIMIT: Optional[int] = Field(gt=0, default=100_000)
     """Max number of repeats / shots to be performed in a single job."""
     DISABLE_PULSE_DURATION_LIMITS: bool = False
     """Flag to disable the lower and upper pulse duration limits. 
     Only needs to be set to True for calibration purposes."""
+
+    SIMULATION: QatSimulationConfig = QatSimulationConfig()
+    """Options for QATs simulation backends."""
 
     @field_validator("DISABLE_PULSE_DURATION_LIMITS")
     def check_disable_pulse_duration_limits(cls, DISABLE_PULSE_DURATION_LIMITS):


### PR DESCRIPTION
Changes made:
- Options for the `AerSimulator` backend can now be passed via qatconfig.
- A fall-back sequence can be provided for `AerSimulator` if the given method fails.
- If simulations using `automatic` or `statevector` fail due to a lack of resources, by default `AerSimulator` will fall back on its MPS backend with a controlled bond dimension. See #129.
- Some basic documentation for the Qiskit backend.