### PR TITLE
Completely decouple package allocation from installation

### DIFF
--- a/tests/qat/qblox/test_config.py
+++ b/tests/qat/qblox/test_config.py
@@ -86,14 +86,21 @@ class TestSequencerConfig(TestQbloxConfigMixin):
         )
         qat_file = InstructionEmitter().emit(builder.instructions, model)
         packages = QbloxEmitter().emit(qat_file)
-        model.control_hardware.allocate_resources(packages)
+        resources = model.control_hardware.allocate_resources(packages)
 
         assert len(packages) == 2
 
         # Drive
         drive_pkg = next((pkg for pkg in packages if pkg.target == drive_channel))
         lo_freq, nco_freq = self.extract_lo_and_nco_freqs(drive_channel)
-        module, sequencer = model.control_hardware.install(drive_pkg)
+        module, sequencer = next(
+            (
+                (m, t2s[drive_pkg.target])
+                for m, t2s in resources.items()
+                if m.slot_idx == drive_pkg.target.physical_channel.slot_idx
+            )
+        )
+        model.control_hardware.install(drive_pkg, module, sequencer)
         assert sequencer.nco_freq() == nco_freq
         if module.out0_lo_en():
             assert module.out0_lo_freq() == lo_freq
@@ -105,7 +112,14 @@ class TestSequencerConfig(TestQbloxConfigMixin):
             (inst for inst in qat_file.instructions if isinstance(inst, Acquire))
         )
         measure_pkg = next((pkg for pkg in packages if pkg.target == measure_channel))
-        module, sequencer = model.control_hardware.install(measure_pkg)
+        module, sequencer = next(
+            (
+                (m, t2s[measure_pkg.target])
+                for m, t2s in resources.items()
+                if m.slot_idx == measure_pkg.target.physical_channel.slot_idx
+            )
+        )
+        model.control_hardware.install(measure_pkg, module, sequencer)
         hwm_seq_config = measure_channel.physical_channel.config.sequencers[
             sequencer.seq_idx
         ]


### PR DESCRIPTION
- Allows Q1 assembly debugging before installation
- Decouples Qblox resource allocation from package installation. This makes the install() method easily reusable for other internal purposes.