### PR TITLE
[Qblox] Reuse complex-shaped waveforms whenever possible

### DIFF
--- a/src/qat/purr/backends/qblox/ir.py
+++ b/src/qat/purr/backends/qblox/ir.py
@@ -95,7 +95,17 @@ class SequenceBuilder:
             ),
         )
 
-    def add_waveform(self, name: str, index: int, data: np.ndarray):
+    def lookup_waveform_by_data(self, data: np.ndarray):
+        return next(
+            (
+                wf["index"]
+                for wf in self.waveforms.values()
+                if (np.array(wf["data"]) == data).all()
+            ),
+            None,
+        )
+
+    def add_waveform(self, name: str, index: int, data: List[float]):
         if name in self.waveforms:
             raise ValueError(f"A waveform named {name} already exists")
         self.waveforms[name] = {"index": index, "data": data}

--- a/tests/qat/qblox/builder_nuggets.py
+++ b/tests/qat/qblox/builder_nuggets.py
@@ -14,7 +14,6 @@ def resonator_spect(model, qubit_indices=None):
         qubit = model.get_qubit(index)
         measure_channel = qubit.get_measure_channel()
         acquire_channel = qubit.get_acquire_channel()
-        assert acquire_channel == measure_channel
 
         center_freq = qubit.get_acquire_channel().frequency
         freqs = center_freq + np.linspace(-freq_range, freq_range, num_points)
@@ -41,9 +40,6 @@ def qubit_spect(model, qubit_indices=None):
     for index in qubit_indices:
         qubit = model.get_qubit(index)
         drive_channel = qubit.get_drive_channel()
-        measure_channel = qubit.get_measure_channel()
-        acquire_channel = qubit.get_acquire_channel()
-        assert acquire_channel == measure_channel
 
         freqs = drive_channel.frequency + np.linspace(-freq_range, freq_range, num_points)
         drive_amp_v = np.sqrt(10 ** (((drive_amp_dbm + 12) / 10) - 1))


### PR DESCRIPTION
- When the waveform envelope is not trivial, try to find an existing waveform entry with the same data.
- Allows further optimisation on the waveform memory