### PR TITLE
Auto-generated release note categorisation based on github PR labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🛠 Breaking Changes 
+      labels:
+        - breaking-change
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: ⚙️ DevOps
+      labels:
+        - devops
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds categorisation of our release notes based on labels added to pull requests. This pull request comes with an implied team consensus that we include 'has appropriate labels' as a check in our code reviewing.

See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

It will look something like this... https://david.gardiner.net.au/assets/2020/07/github-release-notes.png