### PR TITLE
[EXPERIMENTAL] Part 3: Faster Qblox integration

### DIFF
--- a/src/qat/purr/backends/qblox/analysis_passes.py
+++ b/src/qat/purr/backends/qblox/analysis_passes.py
@@ -1,0 +1,165 @@
+from collections import defaultdict
+from typing import Dict, Set
+
+import numpy as np
+
+from qat.backend.analysis_passes import BindingResult, IterBound
+from qat.ir.pass_base import AnalysisPass
+from qat.ir.result_base import ResultManager
+from qat.purr.backends.qblox.constants import Constants
+from qat.purr.compiler.builders import InstructionBuilder
+from qat.purr.compiler.devices import PulseChannel, PulseShapeType
+from qat.purr.compiler.instructions import DeviceUpdate, Instruction, Pulse, Variable
+
+
+class QbloxLegalisationPass(AnalysisPass):
+    """
+    Performs target-dependent legalisation for QBlox.
+
+        A) A repeat instruction with a very high repetition count is illegal because acquisition memory
+    on a QBlox sequencer is limited. This requires optimal batching of the repeat instruction into maximally
+    supported batches of smaller repeat counts.
+
+    This pass does not do any batching. More features and adjustments will follow in future iterations.
+
+        B) Previously processed variables such as frequencies, phases, and amplitudes still need digital conversion
+    to a representation that's required by the QBlox ISA.
+
+    + NCO's 1GHz frequency range by 4e9 steps:
+        + [-500, 500] Mhz <=> [-2e9, 2e9] steps
+        + 1 Hz            <=> 4 steps
+    + NCO's 360° phase range by 1e9 steps:
+        + 1e9    steps    <=> 2*pi rad
+        + 125e6  steps    <=> pi/4 rad
+    + Time and samples are quantified in nanoseconds
+    + Amplitude depends on the type of the module:
+        + [-1, 1]         <=> [-2.5, 2.5] V (for QCM)
+        + [-1, 1]         <=> [-0.5, 0.5] V (for QRM)
+    + AWG offset:
+        + [-1, 1]         <=> [-32 768, 32 767]
+
+    The last point is interesting as it requires knowledge of physical configuration of qubits and the modules
+    they are wired to. This knowledge is typically found during execution and involving it early on would upset
+    the rest of the compilation flow. In fact, it complicates this pass in particular, involves allocation
+    concepts that should not be treated here, and promotes a monolithic compilation style. A temporary workaround
+    is to simply assume the legality of amplitudes from the start whereby users are required to convert
+    the desired voltages to the equivalent ratio AOT.
+
+    This pass performs target-dependent conversion as described in part (B). More features and adjustments
+    will follow in future iterations.
+    """
+
+    @staticmethod
+    def phase_as_steps(phase_rad: float) -> int:
+        phase_deg = np.rad2deg(phase_rad)
+        phase_deg %= 360
+        return int(round(phase_deg * Constants.NCO_PHASE_STEPS_PER_DEG))
+
+    @staticmethod
+    def freq_as_steps(freq_hz: float) -> int:
+        steps = int(round(freq_hz * Constants.NCO_FREQ_STEPS_PER_HZ))
+
+        if (
+            steps < -Constants.NCO_FREQ_LIMIT_STEPS
+            or steps > Constants.NCO_FREQ_LIMIT_STEPS
+        ):
+            min_max_frequency_in_hz = (
+                Constants.NCO_FREQ_LIMIT_STEPS / Constants.NCO_FREQ_STEPS_PER_HZ
+            )
+            raise ValueError(
+                f"IF frequency must be in [-{min_max_frequency_in_hz:e}, {min_max_frequency_in_hz:e}] Hz. "
+                f"Got {freq_hz:e} Hz"
+            )
+
+        return steps
+
+    def _legalise_bound(self, name: str, bound: IterBound, inst: Instruction):
+        if isinstance(inst, DeviceUpdate):
+            if inst.attribute == "frequency":
+                legal_bound = IterBound(
+                    start=self.freq_as_steps(bound.start),
+                    step=self.freq_as_steps(bound.step),
+                    end=self.freq_as_steps(bound.end),
+                    count=bound.count,
+                )
+            elif inst.attribute == "phase":
+                legal_bound = IterBound(
+                    start=self.phase_as_steps(bound.start),
+                    step=self.phase_as_steps(bound.step),
+                    end=self.phase_as_steps(bound.end),
+                    count=bound.count,
+                )
+            else:
+                raise NotImplementedError(
+                    f"Unsupported processing of attribute {inst.attribute}"
+                )
+        elif isinstance(inst, Pulse):
+            if inst.shape != PulseShapeType.SQUARE:
+                raise ValueError("Cannot process non-trivial pulses")
+
+            attribute = next(
+                (
+                    attr
+                    for attr, var in inst.__dict__.items()
+                    if isinstance(var, Variable) and var.name == name
+                )
+            )
+            if attribute == "width":
+                # TODO - as nanoseconds for now but involve calculate_duration
+                legal_bound = IterBound(
+                    start=bound.start * 1e9,
+                    step=bound.step * 1e9,
+                    end=bound.end * 1e9,
+                    count=bound.count,
+                )
+            elif attribute == "amp":
+                # TODO - Assumed legal whereby users know about ADC ratio <-> Voltage <-> bit representation rules
+                legal_bound = bound
+            else:
+                raise NotImplementedError(
+                    f"Unsupported processing of {attribute} for instruction {inst}"
+                )
+        else:
+            raise NotImplementedError(
+                f"Legalisation only supports DeviceUpdate and Pulse. Got {type(inst)} instead"
+            )
+
+        if not all(
+            isinstance(val, int)
+            for val in [
+                legal_bound.start,
+                legal_bound.step,
+                legal_bound.end,
+                legal_bound.end,
+            ]
+        ):
+            raise ValueError(
+                f"Illegal iter bound. Expected all attribute to be integer, but got {legal_bound} instead"
+            )
+
+        # Qblox registers are unsigned 32bit integers, but they are treated as signed integers
+        return IterBound(
+            start=np.array([legal_bound.start], dtype=int).view(np.uint32)[0],
+            step=np.array([legal_bound.step], dtype=int).view(np.uint32)[0],
+            end=np.array([legal_bound.end], dtype=int).view(np.uint32)[0],
+            count=legal_bound.count,
+        )
+
+    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+        binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)
+
+        qblox_iter_bounds: Dict[PulseChannel, Dict[str, Set[IterBound]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
+        for name, instructions in binding_result.reads.items():
+            for inst in instructions:
+                for target in inst.quantum_targets:
+                    bound = binding_result.iter_bounds[target][name]
+                    legal_bound = self._legalise_bound(name, bound, inst)
+                    qblox_iter_bounds[target][name].add(legal_bound)
+
+        for target, symbol2iter_bounds in qblox_iter_bounds.items():
+            for name, iter_bounds in symbol2iter_bounds.items():
+                if len(iter_bounds) > 1:
+                    raise ValueError(f"Ambiguous Qblox bounds for variable {name}")
+                binding_result.iter_bounds[target][name] = next(iter(iter_bounds))

--- a/src/qat/purr/backends/qblox/codegen.py
+++ b/src/qat/purr/backends/qblox/codegen.py
@@ -1,19 +1,27 @@
+from collections import defaultdict
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from typing import Dict, List
 
 import numpy as np
 
+from qat.backend.analysis_passes import BindingResult, CFGResult, IterBound, TriageResult
+from qat.backend.codegen_base import DfsTraversal
+from qat.backend.graph import ControlFlowGraph
+from qat.ir.pass_base import AnalysisPass, InvokerMixin, PassManager
+from qat.ir.result_base import ResultManager
 from qat.purr.backends.qblox.config import SequencerConfig
 from qat.purr.backends.qblox.constants import Constants
 from qat.purr.backends.qblox.ir import Opcode, Sequence, SequenceBuilder
 from qat.purr.backends.utilities import evaluate_shape
+from qat.purr.compiler.builders import InstructionBuilder
 from qat.purr.compiler.devices import PulseChannel, PulseShapeType
 from qat.purr.compiler.emitter import QatFile
 from qat.purr.compiler.instructions import (
     Acquire,
     CustomPulse,
     Delay,
+    DeviceUpdate,
     FrequencyShift,
     Id,
     MeasurePulse,
@@ -23,7 +31,9 @@ from qat.purr.compiler.instructions import (
     Pulse,
     QuantumInstruction,
     Repeat,
+    Sweep,
     Synchronize,
+    Variable,
     Waveform,
 )
 from qat.purr.utils.logger import get_default_logger
@@ -582,3 +592,613 @@ class QbloxContext:
         value = get_nco_set_frequency_arguments(shifted_nco_freq)  # 1 MHZ <-> 4e6
         self.sequence_builder.set_freq(value)
         self.sequence_builder.upd_param(Constants.GRID_TIME)
+
+
+@dataclass
+class AllocationManager:
+    _reg_pool: List[str] = field(
+        default_factory=lambda: sorted(
+            f"R{index}" for index in range(Constants.NUMBER_OF_REGISTERS)
+        )
+    )
+    _lbl_counters: Dict[str, int] = field(default_factory=dict)
+    registers: Dict[str, str] = field(default_factory=dict)
+    labels: Dict[str, str] = field(default_factory=dict)
+
+    def reg_alloc(self, name: str) -> str:
+        if len(self._reg_pool) < 1:
+            raise IndexError(
+                "Out of registers. Attempting to use more registers "
+                "than available in the Q1 sequence processor"
+            )
+        register = self._reg_pool.pop(0)
+        self.registers[name] = register
+        return register
+
+    def reg_free(self, register: str) -> None:
+        if register in self._reg_pool:
+            raise RuntimeError(f"Cannot free register '{register}' as it's not in use")
+        self.registers = {
+            var: reg for var, reg in self.registers.items() if reg != register
+        }
+        self._reg_pool.append(register)
+
+    def gen_label(self, name: str):
+        counter = self._lbl_counters.setdefault(name, 0)
+        self._lbl_counters[name] += 1
+        label = f"{name}_{counter}"
+        self.labels[name] = label
+        return label
+
+
+class NewQbloxContext:
+    def __init__(self, alloc_mgr: AllocationManager, iter_bounds: Dict[str, IterBound]):
+        self.alloc_mgr = alloc_mgr
+        self.iter_bounds = iter_bounds
+
+        self.sequence_builder = SequenceBuilder()
+        self.sequencer_config = SequencerConfig()
+
+        self._duration: int = 0
+        self._timeline: np.ndarray = np.empty(0, dtype=complex)
+
+        self._num_hw_avg = 1  # Technically disabled
+        self._wf_memory: int = Constants.MAX_SAMPLE_SIZE_WAVEFORMS
+        self._wf_index: int = 0
+        self._acq_index: int = 0
+
+        self._frequency: float = 0.0  # Keeps record of the frequency shift on the target
+
+    @contextmanager
+    def _loop(self, label: str, iter_count: int = 1):
+        """
+        This context can be used to avoid unrolling loops but needs manual addition of the 0 iteration
+        either immediately after the yield or immediately after the context has exited.
+        """
+        register = self.alloc_mgr.reg_alloc(label)
+        label = self.alloc_mgr.gen_label(label)
+        self.sequence_builder.move(iter_count, register)
+        self.sequence_builder.label(label)
+        yield register
+        self.sequence_builder.loop(register, label)
+        self.alloc_mgr.reg_free(register)
+
+    @property
+    def duration(self):
+        return self._duration
+
+    def is_empty(self):
+        """
+        Masks away yet-to-be-supported second-state, cancellation, and cross cancellation targets
+        This is temporary and criteria will change with more features coming in
+        """
+        return not (
+            self.sequence_builder.waveforms
+            or self.sequence_builder.acquisitions
+            or [
+                inst
+                for inst in self.sequence_builder.q1asm_instructions
+                if inst.opcode
+                in [
+                    Opcode.PLAY,
+                    Opcode.SET_AWG_OFFSET,
+                    Opcode.SET_AWG_GAIN,
+                    Opcode.ACQUIRE,
+                    Opcode.ACQUIRE_TTL,
+                    Opcode.ACQUIRE_WEIGHED,
+                ]
+            ]
+        )
+
+    def clear(self):
+        self.sequence_builder.waveforms.clear()
+        self.sequence_builder.acquisitions.clear()
+        self.sequence_builder.weights.clear()
+        self.sequence_builder.q1asm_instructions.clear()
+
+    def create_package(self, target: PulseChannel):
+        sequence = self.sequence_builder.build()
+        return QbloxPackage(target, sequence, self.sequencer_config, self._timeline)
+
+    def _wait_seconds(self, duration: float):
+        if duration <= 0:
+            return
+
+        self._wait_nanoseconds(int(duration * 1e9))
+
+    def _wait_nanoseconds(self, duration: int):
+        if duration <= 0:
+            return
+
+        quotient = duration // Constants.MAX_WAIT_TIME
+        remainder = duration % Constants.MAX_WAIT_TIME
+        if quotient > Constants.LOOP_UNROLL_THRESHOLD:
+            with self._loop("wait_label", quotient):
+                self.sequence_builder.wait(Constants.MAX_WAIT_TIME)
+        elif quotient >= 1:
+            for _ in range(quotient):
+                self.sequence_builder.wait(Constants.MAX_WAIT_TIME)
+
+        if remainder > 0:
+            self.sequence_builder.wait(remainder)
+
+    def _evaluate_waveform(self, waveform: Waveform, target: PulseChannel):
+        """
+        The waveform is evaluated as a 1d complex array. In QBlox, the Real and Imag parts of the pulse
+        represent the digital offset on the AWG. They both must be within range [-1, 1].
+        """
+
+        num_samples = int(calculate_duration(waveform, return_samples=True))
+        if num_samples < Constants.GRID_TIME:
+            if num_samples == 0:
+                log.warning(f"Empty pulse.")
+            else:
+                log.warning(
+                    f"""
+                    Minimum pulse width is {Constants.GRID_TIME} ns with a resolution of {1} ns.
+                    Please round up the width to at least {Constants.GRID_TIME} nanoseconds.
+                    """
+                )
+            return None
+
+        dt = target.sample_time
+        length = num_samples * dt
+        centre = length / 2.0
+        t = np.linspace(
+            start=-centre + 0.5 * dt, stop=length - centre - 0.5 * dt, num=num_samples
+        )
+        pulse = evaluate_shape(waveform, t)
+        scale = target.scale
+        if isinstance(waveform, (Pulse, CustomPulse)) and waveform.ignore_channel_scale:
+            scale = 1
+
+        pulse *= scale
+        pulse += target.bias
+
+        if ((pulse.real < -1) | (pulse.real > 1)).any():
+            raise ValueError(
+                "Voltage range for I exceeded. Make sure all I values are within the range [-1, 1]"
+            )
+        if ((pulse.imag < -1) | (pulse.imag > 1)).any():
+            raise ValueError(
+                "Voltage range for Q exceeded. Make sure all I values are within the range [-1, 1]"
+            )
+
+        if ((pulse.real > 0.3) | (pulse.imag > 0.3)).any():
+            log.warning(
+                """
+                Values above 0.3 will overdrive the mixer and  produce intermodulation distortion.
+                Consider adjusting attenuation instead.
+                """
+            )
+
+        return pulse
+
+    def _register_signal(self, waveform, target, data, name):
+        index = self.sequence_builder.lookup_waveform_by_data(data)
+        if index is not None:
+            log.debug(
+                f"Reusing signal {name} at index {index} for pulse {waveform} on channel {target}"
+            )
+        elif data.size > self._wf_memory:
+            raise ValueError(
+                f"No more waveform memory left for signal {name} of pulse {waveform} on channel {target}"
+            )
+        else:
+            wf_hash = hash(waveform)
+            wf_name = type(waveform).__name__
+            if isinstance(waveform, Pulse):
+                wf_name = waveform.shape.name
+
+            index = self._wf_index
+            self.sequence_builder.add_waveform(
+                f"{wf_name}_{wf_hash}_{name}", index, data.tolist()
+            )
+            self._wf_memory = self._wf_memory - data.size
+            self._wf_index = self._wf_index + 1
+
+        return index
+
+    def _register_waveform(self, waveform, target, data):
+        i_index = self._register_signal(waveform, target, data.real, "I")
+        q_index = self._register_signal(waveform, target, data.imag, "Q")
+        return i_index, q_index
+
+    def _register_acquisition(self, acquire: Acquire):
+        num_bins = self.iter_bounds[acquire.output_variable].count
+        acq_index = self._acq_index
+        self.sequence_builder.add_acquisition(acquire.output_variable, acq_index, num_bins)
+        self._acq_index = acq_index + 1
+        return acq_index
+
+    def _binned_acquisition(
+        self,
+        delay,
+        acq_index,
+        bin_reg,
+        num_samples,
+        pulse_shape,
+        i_steps,
+        q_steps,
+        i_index,
+        q_index,
+    ):
+        capped_num_samples = min(num_samples, Constants.MAX_WAIT_TIME)
+        flight_nanos = int(delay * 1e9)
+        capped_flight_nanos = min(flight_nanos, Constants.MAX_WAIT_TIME)
+        if pulse_shape == PulseShapeType.SQUARE:
+            self.sequence_builder.set_awg_offs(i_steps, q_steps)
+            self._wait_seconds(delay)
+            self.sequence_builder.acquire(
+                acq_index,
+                bin_reg,
+                capped_num_samples,
+            )
+            self._wait_seconds((num_samples - capped_num_samples) / 1e9)
+            self.sequence_builder.set_awg_offs(0, 0)
+            self.sequence_builder.upd_param(Constants.GRID_TIME)
+            self.sequence_builder.add(bin_reg, 1, bin_reg)
+        else:
+            self.sequence_builder.play(i_index, q_index, capped_flight_nanos)
+            self._wait_seconds((flight_nanos - capped_flight_nanos) / 1e9)
+            self.sequence_builder.acquire(
+                acq_index,
+                bin_reg,
+                capped_num_samples,
+            )
+            self._wait_seconds((num_samples - capped_num_samples) / 1e9)
+            self.sequence_builder.add(bin_reg, 1, bin_reg)
+
+    def id(self):
+        self.sequence_builder.nop()
+
+    def delay(self, inst: Delay):
+        self._wait_seconds(inst.duration)
+
+        if inst.duration <= 0:
+            return
+
+        self._duration = self._duration + inst.duration
+        num_samples = int(calculate_duration(inst))
+        self._timeline = np.append(self._timeline, [0] * num_samples)
+
+    def waveform(self, waveform: Waveform, target: PulseChannel):
+        pulse = self._evaluate_waveform(waveform, target)
+        if pulse is None:
+            log.warning("This pulse will be ignored.")
+            return
+
+        num_samples = pulse.size
+        max_duration = min(num_samples, Constants.MAX_WAIT_TIME)
+        if isinstance(waveform, Pulse) and waveform.shape == PulseShapeType.SQUARE:
+            i_offs_steps = int(
+                pulse[0].real * (Constants.MAX_OFFSET_SIZE // 2)  # Signed integer
+            )
+            q_offs_steps = int(
+                pulse[0].imag * (Constants.MAX_OFFSET_SIZE // 2)  # Signed integer
+            )
+            self.sequence_builder.set_awg_offs(i_offs_steps, q_offs_steps)
+            self.sequence_builder.upd_param(max_duration)
+            self._wait_seconds((num_samples - max_duration) / 1e9)
+            self.sequence_builder.set_awg_offs(0, 0)
+            self.sequence_builder.upd_param(Constants.GRID_TIME)
+        else:
+            i_index, q_index = self._register_waveform(waveform, target, pulse)
+            self.sequence_builder.play(i_index, q_index, max_duration)
+            self._wait_seconds((num_samples - max_duration) / 1e9)
+
+        self._duration = self._duration + waveform.duration
+        self._timeline = np.append(self._timeline, pulse)
+
+    def measure_acquire(
+        self, measure: MeasurePulse, acquire: Acquire, target: PulseChannel
+    ):
+        pulse = self._evaluate_waveform(measure, target)
+        if pulse is None:
+            log.warning("This pulse will be ignored.")
+            return
+
+        acq_index = self._register_acquisition(acquire)
+        bin_reg = self.alloc_mgr.registers[acquire.output_variable]
+        self.sequencer_config.square_weight_acq.integration_length = calculate_duration(
+            acquire
+        )
+
+        i_steps, q_steps = None, None
+        i_index, q_index = None, None
+        if measure.shape == PulseShapeType.SQUARE:
+            i_steps = int(pulse[0].real * (Constants.MAX_OFFSET_SIZE // 2))
+            q_steps = int(pulse[0].imag * (Constants.MAX_OFFSET_SIZE // 2))
+        else:
+            i_index, q_index = self._register_waveform(measure, target, pulse)
+
+        if self._num_hw_avg <= Constants.LOOP_UNROLL_THRESHOLD:
+            for _ in range(self._num_hw_avg):
+                self._binned_acquisition(
+                    acquire.delay,
+                    acq_index,
+                    bin_reg,
+                    pulse.size,
+                    measure.shape,
+                    i_steps,
+                    q_steps,
+                    i_index,
+                    q_index,
+                )
+        else:
+            with self._loop("avg_label", self._num_hw_avg + 1):
+                self._binned_acquisition(
+                    acquire.delay,
+                    acq_index,
+                    bin_reg,
+                    pulse.size,
+                    measure.shape,
+                    i_steps,
+                    q_steps,
+                    i_index,
+                    q_index,
+                )
+
+        self._duration = self._duration + measure.duration
+        self._timeline = np.append(self._timeline, pulse)
+
+    @staticmethod
+    def synchronize(inst: Synchronize, contexts: Dict):
+        max_duration = max([cxt.duration for cxt in contexts.values()])
+        for target in inst.quantum_targets:
+            cxt = contexts[target]
+            delay_time = max_duration - cxt.duration
+            cxt.delay(Delay(target, delay_time))
+            # TODO - For now, enable only logical time padding
+            # TODO - Enable when finer grained SYNC groups are supported
+            # cxt.sequence_builder.wait_sync(Constants.GRID_TIME)
+
+    @staticmethod
+    def reset_phase(inst: PhaseReset, contexts: Dict):
+        for target in inst.quantum_targets:
+            cxt = contexts[target]
+            cxt._phase = 0.0
+            cxt.sequence_builder.reset_ph()
+            cxt.sequence_builder.upd_param(Constants.GRID_TIME)
+
+    def shift_phase(self, inst: PhaseShift):
+        value = get_nco_phase_arguments(inst.phase)
+        self.sequence_builder.set_ph_delta(value)
+        self.sequence_builder.upd_param(Constants.GRID_TIME)
+
+    def shift_frequency(self, inst, target):
+        # TODO - discuss w/t quantum_target.fixed_if is True or False
+        old_frequency = target.frequency + self._frequency
+        new_frequency = old_frequency + inst.frequency
+        if new_frequency < target.min_frequency or new_frequency > target.max_frequency:
+            raise ValueError(
+                f"Cannot shift pulse channel frequency from '{old_frequency}' to '{new_frequency}'"
+            )
+
+        self._frequency = self._frequency + inst.frequency
+        shifted_nco_freq = target.baseband_if_frequency + self._frequency
+        value = get_nco_set_frequency_arguments(shifted_nco_freq)  # 1 MHZ <-> 4e6
+        self.sequence_builder.set_freq(value)
+        self.sequence_builder.upd_param(Constants.GRID_TIME)
+
+    def device_update(self, du_inst: DeviceUpdate):
+        value = du_inst.value
+        if isinstance(value, Variable):
+            value = self.alloc_mgr.registers[value.name]
+
+        if du_inst.attribute == "frequency":
+            self.sequence_builder.set_freq(value)
+            self.sequence_builder.upd_param(Constants.GRID_TIME)
+        elif du_inst.attribute == "phase":
+            self.sequence_builder.set_ph(value)
+            self.sequence_builder.upd_param(Constants.GRID_TIME)
+        else:
+            raise NotImplementedError(
+                f"Unsupported processing of attribute {du_inst.attribute}"
+            )
+
+    @staticmethod
+    def enter_repeat(inst: Repeat, contexts: Dict):
+        name = f"repeat_{inst.repeat_count}_{hash(inst)}"
+        for context in contexts.values():
+            register = context.alloc_mgr.registers[name]
+            label = context.alloc_mgr.labels[name]
+            bound = context.iter_bounds[name]
+
+            context.sequence_builder.move(bound.start, register)
+            context.sequence_builder.label(label)
+            context.sequence_builder.reset_ph()
+            context.sequence_builder.upd_param(Constants.GRID_TIME)
+
+    @staticmethod
+    def exit_repeat(inst: Repeat, contexts: Dict):
+        name = f"repeat_{inst.repeat_count}_{hash(inst)}"
+        for context in contexts.values():
+            register = context.alloc_mgr.registers[name]
+            label = context.alloc_mgr.labels[name]
+            bound = context.iter_bounds[name]
+
+            context._wait_seconds(inst.repetition_period)
+            context.sequence_builder.add(register, bound.step, register)
+            context.sequence_builder.jlt(
+                register, bound.end + bound.step, label
+            )  # extra step for jlt
+
+    @staticmethod
+    def enter_sweep(inst: Sweep, contexts: Dict):
+        for name in inst.variables.keys():
+            for context in contexts.values():
+                register = context.alloc_mgr.registers[name]
+                label = context.alloc_mgr.labels[name]
+                bound = context.iter_bounds[name]
+
+                context.sequence_builder.move(bound.start, register)
+                context.sequence_builder.label(label)
+
+    @staticmethod
+    def exit_sweep(inst: Sweep, contexts: Dict):
+        for name in inst.variables.keys():
+            for context in contexts.values():
+                register = context.alloc_mgr.registers[name]
+                label = context.alloc_mgr.labels[name]
+                bound = context.iter_bounds[name]
+
+                context.sequence_builder.add(register, bound.step, register)
+                context.sequence_builder.jlt(
+                    register, bound.end + bound.step, label
+                )  # extra step for jlt
+
+    @staticmethod
+    def prologue(contexts: Dict):
+        for context in contexts.values():
+            context.sequence_builder.set_mrk(3)
+            context.sequence_builder.upd_param(Constants.GRID_TIME)
+
+            for name, register in context.alloc_mgr.registers.items():
+                context.sequence_builder.move(0, register)
+
+    @staticmethod
+    def epilogue(contexts: Dict):
+        for context in contexts.values():
+            context.sequence_builder.stop()
+
+
+@dataclass
+class PreCodegenResult:
+    alloc_mgrs: Dict[PulseChannel, AllocationManager] = field(
+        default_factory=lambda: defaultdict(lambda: AllocationManager())
+    )
+
+
+class PreCodegenPass(AnalysisPass):
+    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+        """
+        Precedes assembly codegen.
+        Performs a naive register allocation through a manager object.
+        Computes useful information in the form of attributes.
+        """
+
+        triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
+        binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)
+        result = PreCodegenResult()
+
+        for name, instructions in binding_result.writes.items():
+            for inst in instructions:
+                targets = (
+                    inst.quantum_targets
+                    if isinstance(inst, QuantumInstruction)
+                    else triage_result.target_map.keys()
+                )
+                for target in targets:
+                    result.alloc_mgrs[target].reg_alloc(name)
+                    result.alloc_mgrs[target].gen_label(name)
+
+        res_mgr.add(result)
+
+
+class NewQbloxEmitter(InvokerMixin):
+    def build_pass_pipeline(self, *args, **kwargs):
+        return PassManager() | PreCodegenPass()
+
+    def emit_packages(
+        self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs
+    ) -> List[QbloxPackage]:
+        self.run_pass_pipeline(builder, res_mgr, *args, **kwargs)
+
+        cfg_result: CFGResult = res_mgr.lookup_by_type(CFGResult)
+        triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
+        binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)
+        precodegen_result: PreCodegenResult = res_mgr.lookup_by_type(PreCodegenResult)
+
+        alloc_mgrs: Dict[PulseChannel, AllocationManager] = precodegen_result.alloc_mgrs
+        iter_bounds: Dict[PulseChannel, Dict[str, IterBound]] = binding_result.iter_bounds
+
+        contexts = {
+            t: NewQbloxContext(alloc_mgr=alloc_mgrs[t], iter_bounds=iter_bounds[t])
+            for t in triage_result.target_map
+        }
+        cfg_walker = QbloxCFGWalker(contexts)
+        cfg_walker.walk(cfg_result.cfg)
+
+        # Digard empty contexts
+        return [
+            context.create_package(target)
+            for target, context in contexts.items()
+            if not context.is_empty()
+        ]
+
+
+class QbloxCFGWalker(DfsTraversal):
+    def __init__(self, contexts: Dict[PulseChannel, NewQbloxContext]):
+        super().__init__()
+        self.contexts = contexts
+
+    def enter(self, block):
+        iterator = block.iterator()
+        while (inst := next(iterator, None)) is not None:
+            if isinstance(inst, Sweep):
+                NewQbloxContext.enter_sweep(inst, self.contexts)
+            elif isinstance(inst, Repeat):
+                NewQbloxContext.enter_repeat(inst, self.contexts)
+            elif isinstance(inst, QuantumInstruction):
+                if isinstance(inst, PostProcessing):
+                    continue
+                elif isinstance(inst, Synchronize):
+                    NewQbloxContext.synchronize(inst, self.contexts)
+                    continue
+                elif isinstance(inst, PhaseReset):
+                    NewQbloxContext.reset_phase(inst, self.contexts)
+                    continue
+
+                for target in inst.quantum_targets:
+                    context = self.contexts[target]
+                    if isinstance(inst, DeviceUpdate):
+                        context.device_update(inst)
+                    if isinstance(inst, MeasurePulse):
+                        next_inst = next(iterator, None)
+                        if next_inst is None or not isinstance(next_inst, Acquire):
+                            raise ValueError(
+                                "Found a MeasurePulse but no Acquire instruction followed"
+                            )
+
+                        # TODO - Move to a dedicated pass on the cfg (batching or ctrl-hw related)
+                        num_bins = 1
+                        for block in self._entered:
+                            head = block.head()
+                            if isinstance(head, Sweep):
+                                name = next(iter(head.variables.keys()))
+                                iter_bound = context.iter_bounds[name]
+                                num_bins *= iter_bound.count
+                            elif isinstance(head, Repeat):
+                                name = f"repeat_{head.repeat_count}_{hash(head)}"
+                                iter_bound = context.iter_bounds[name]
+                                num_bins *= iter_bound.count
+                        context.iter_bounds[next_inst.output_variable] = IterBound(
+                            start=0, step=1, end=num_bins, count=num_bins
+                        )
+                        context.measure_acquire(inst, next_inst, target)
+                    elif isinstance(inst, Waveform):
+                        context.waveform(inst, target)
+                    elif isinstance(inst, Delay):
+                        context.delay(inst)
+                    elif isinstance(inst, PhaseShift):
+                        context.shift_phase(inst)
+                    elif isinstance(inst, FrequencyShift):
+                        context.shift_frequency(inst, target)
+                    elif isinstance(inst, Id):
+                        context.id()
+
+    def exit(self, block):
+        iterator = block.iterator()
+        while (inst := next(iterator, None)) is not None:
+            if isinstance(inst, Repeat):
+                NewQbloxContext.exit_repeat(inst, self.contexts)
+            elif isinstance(inst, Sweep):
+                NewQbloxContext.exit_sweep(inst, self.contexts)
+
+    def walk(self, cfg: ControlFlowGraph):
+        # TODO - run as visit to the entry block
+        NewQbloxContext.prologue(self.contexts)
+        self.run(cfg)
+        # TODO - run as visit to the exit block
+        NewQbloxContext.epilogue(self.contexts)

--- a/src/qat/purr/backends/qblox/constants.py
+++ b/src/qat/purr/backends/qblox/constants.py
@@ -1,6 +1,3 @@
-import numpy as np
-
-
 class Constants:
     MAX_GAIN_SIZE = pow(2, 16) - 1
     """Max size of gain in Q1ASM programs."""
@@ -72,29 +69,3 @@ class Constants:
     """
     Maximum offset for QRM-RF
     """
-
-
-class ConversionHelper:
-    @staticmethod
-    def phase_as_steps(phase_rad: float) -> int:
-        phase_deg = np.rad2deg(phase_rad)
-        phase_deg %= 360
-        return int(round(phase_deg * Constants.NCO_PHASE_STEPS_PER_DEG))
-
-    @staticmethod
-    def freq_as_steps(freq_hz: float) -> int:
-        steps = int(round(freq_hz * Constants.NCO_FREQ_STEPS_PER_HZ))
-
-        if (
-            steps < -Constants.NCO_FREQ_LIMIT_STEPS
-            or steps > Constants.NCO_FREQ_LIMIT_STEPS
-        ):
-            min_max_frequency_in_hz = (
-                Constants.NCO_FREQ_LIMIT_STEPS / Constants.NCO_FREQ_STEPS_PER_HZ
-            )
-            raise ValueError(
-                f"IF frequency must be in [-{min_max_frequency_in_hz:e}, {min_max_frequency_in_hz:e}] Hz. "
-                f"Got {freq_hz:e} Hz"
-            )
-
-        return steps

--- a/src/qat/purr/backends/qblox/live.py
+++ b/src/qat/purr/backends/qblox/live.py
@@ -1,15 +1,33 @@
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
+from compiler_config.config import InlineResultsProcessing
 
+from qat.backend.analysis_passes import (
+    BindingPass,
+    CFGPass,
+    TILegalisationPass,
+    TriagePass,
+    TriageResult,
+)
+from qat.backend.transform_passes import (
+    RepeatSanitisation,
+    ReturnSanitisation,
+    ScopeSanitisation,
+)
+from qat.ir.pass_base import InvokerMixin, PassManager
+from qat.ir.result_base import ResultManager
 from qat.purr.backends.live import LiveDeviceEngine, LiveHardwareModel
 from qat.purr.backends.live_devices import ControlHardware
-from qat.purr.backends.qblox.codegen import QbloxEmitter
+from qat.purr.backends.qblox.analysis_passes import QbloxLegalisationPass
+from qat.purr.backends.qblox.codegen import NewQbloxEmitter, QbloxEmitter
 from qat.purr.backends.utilities import get_axis_map
 from qat.purr.compiler.emitter import QatFile
-from qat.purr.compiler.execution import SweepIterator
-from qat.purr.compiler.instructions import AcquireMode
-from qat.purr.compiler.interrupt import NullInterrupt
+from qat.purr.compiler.execution import SweepIterator, _binary_average, _numpy_array_to_list
+from qat.purr.compiler.instructions import AcquireMode, IndexAccessor, Instruction, Variable
+from qat.purr.compiler.interrupt import Interrupt, NullInterrupt
+from qat.purr.compiler.runtime import NewQuantumRuntime
+from qat.purr.utils.logging_utils import log_duration
 
 
 class QbloxLiveHardwareModel(LiveHardwareModel):
@@ -17,8 +35,12 @@ class QbloxLiveHardwareModel(LiveHardwareModel):
         super().__init__(control_hardware)
         self._reverse_coercion()
 
-    def create_engine(self):
-        return QbloxLiveEngine(self)
+    def create_engine(self, startup_engine: bool = True):
+        return QbloxLiveEngineAdapter(self, startup_engine)
+
+    def create_runtime(self, existing_engine=None):
+        existing_engine = existing_engine or self.create_engine()
+        return NewQuantumRuntime(existing_engine)
 
     def _reverse_coercion(self):
         """
@@ -41,6 +63,13 @@ class QbloxLiveEngine(LiveDeviceEngine):
         if self.model.control_hardware is None:
             raise ValueError(f"Please add a control hardware first!")
         self.model.control_hardware.disconnect()
+
+    def _common_execute(self, builder, interrupt: Interrupt = NullInterrupt()):
+        """
+        Wrapper override that accepts an InstructionBuilder
+        """
+
+        return super()._common_execute(builder.instructions, interrupt)
 
     def _execute_on_hardware(
         self, sweep_iterator: SweepIterator, package: QatFile, interrupt=NullInterrupt()
@@ -105,3 +134,182 @@ class QbloxLiveEngine(LiveDeviceEngine):
                     sweep_iterator.insert_result_at_sweep_position(var_result, response)
 
         return results
+
+
+class NewQbloxLiveEngine(LiveDeviceEngine, InvokerMixin):
+    def startup(self):
+        if self.model.control_hardware is None:
+            raise ValueError(f"Please add a control hardware first!")
+        self.model.control_hardware.connect()
+
+    def shutdown(self):
+        if self.model.control_hardware is None:
+            raise ValueError(f"Please add a control hardware first!")
+        self.model.control_hardware.disconnect()
+
+    def optimize(self, instructions):
+        pass
+
+    def validate(self, instructions: List[Instruction]):
+        pass
+
+    def build_pass_pipeline(self, *args, **kwargs):
+        return (
+            PassManager()
+            | RepeatSanitisation()
+            | ScopeSanitisation()
+            | ReturnSanitisation()
+            | TriagePass()
+            | BindingPass()
+            | CFGPass()
+            | TILegalisationPass()
+            | QbloxLegalisationPass()
+        )
+
+    def _common_execute(self, builder, interrupt: Interrupt = NullInterrupt()):
+        self._model_exists()
+
+        with log_duration("Codegen run in {} seconds."):
+            res_mgr = ResultManager()
+            self.run_pass_pipeline(builder, res_mgr, self.model)
+            packages = NewQbloxEmitter().emit_packages(builder, res_mgr, self.model)
+
+        with log_duration("QPU returned results in {} seconds."):
+            self.model.control_hardware.set_data(packages)
+            playback_results: Dict[str, np.ndarray] = (
+                self.model.control_hardware.start_playback(None, None)
+            )
+
+            # Post execution step needs a lot of work
+            # TODO - Robust batching analysis (as a pass !)
+            # TODO - Lowerability analysis pass
+
+            triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
+            acquire_map = triage_result.acquire_map
+            pp_map = triage_result.pp_map
+            sweeps = triage_result.sweeps
+
+            def create_sweep_iterator():
+                switerator = SweepIterator()
+                for sweep in sweeps:
+                    switerator.add_sweep(sweep)
+                return switerator
+
+            results = {}
+            for t, acquires in acquire_map.items():
+                switerator = create_sweep_iterator()
+                for acq in acquires:
+                    big_response = playback_results[acq.output_variable]
+                    sweep_splits = np.split(big_response, switerator.length)
+                    switerator.reset_iteration()
+                    while not switerator.is_finished():
+                        # just to advance iteration, no need for injection
+                        # TODO - A generic loop nest model. Sth similar to SweepIterator but does not mixin injection stuff
+                        switerator.do_sweep([])
+                        response = sweep_splits[switerator.current_iteration]
+                        response_axis = get_axis_map(acq.mode, response)
+                        for pp in pp_map[acq.output_variable]:
+                            response, response_axis = self.run_post_processing(
+                                pp, response, response_axis
+                            )
+                            handle = results.setdefault(
+                                acq.output_variable,
+                                np.empty(
+                                    switerator.get_results_shape(response.shape),
+                                    response.dtype,
+                                ),
+                            )
+                            switerator.insert_result_at_sweep_position(handle, response)
+
+            results = self._process_results(results, triage_result)
+            results = self._process_assigns(results, triage_result)
+
+            return results
+
+    def _process_results(self, results, triage_result: TriageResult):
+        """
+        Process any software-driven results transformation, such as taking a raw
+        waveform result and turning it into a bit, or something else.
+        """
+
+        rp_map = triage_result.rp_map
+
+        for inst in rp_map.values():
+            target_values = results.get(inst.variable, None)
+            if target_values is None:
+                raise ValueError(f"Variable {inst.variable} not found in results output.")
+
+            if (
+                InlineResultsProcessing.Raw in inst.results_processing
+                and InlineResultsProcessing.Binary in inst.results_processing
+            ):
+                raise ValueError(
+                    f"Raw and Binary processing attempted to be applied "
+                    f"to {inst.variable}. Only one should be selected."
+                )
+
+            # Strip numpy arrays if we're set to do so.
+            if InlineResultsProcessing.NumpyArrays not in inst.results_processing:
+                target_values = _numpy_array_to_list(target_values)
+
+            # Transform to various formats if required.
+            if InlineResultsProcessing.Binary in inst.results_processing:
+                target_values = _binary_average(target_values)
+
+            results[inst.variable] = target_values
+
+        return results
+
+    def _process_assigns(self, results, triage_result: TriageResult):
+        """
+        As assigns are classical instructions they are not processed as a part of the
+        quantum execution (right now).
+        Read through the results dictionary and perform the assigns directly, return the
+        results.
+        """
+
+        def recurse_arrays(results_map, value):
+            """Recurse through assignment lists and fetch values in sequence."""
+            if isinstance(value, List):
+                return [recurse_arrays(results_map, val) for val in value]
+            elif isinstance(value, Variable):
+                if value.name not in results_map:
+                    raise ValueError(
+                        f"Attempt to assign variable that doesn't exist {value.name}."
+                    )
+
+                if isinstance(value, IndexAccessor):
+                    return results_map[value.name][value.index]
+                else:
+                    return results_map[value.name]
+            else:
+                return value
+
+        assigns = triage_result.assigns
+        ret_inst = next(iter(triage_result.returns))
+        assigned_results = dict(results)
+        for assign in assigns:
+            assigned_results[assign.name] = recurse_arrays(assigned_results, assign.value)
+
+        return {key: assigned_results[key] for key in ret_inst.variables}
+
+
+class QbloxLiveEngineAdapter(LiveDeviceEngine):
+
+    model: QbloxLiveHardwareModel
+
+    def __init__(
+        self,
+        model: QbloxLiveHardwareModel,
+        startup_engine: bool = True,
+        enable_hax=False,
+    ):
+        super().__init__(model, startup_engine)
+        self._legacy_engine = QbloxLiveEngine(model, False)
+        self._new_engine = NewQbloxLiveEngine(model, False)
+        self.enable_hax = enable_hax
+
+    def _common_execute(self, builder, interrupt: Interrupt = NullInterrupt()):
+        if self.enable_hax:
+            return self._new_engine._common_execute(builder, interrupt)
+        return self._legacy_engine._common_execute(builder, interrupt)

--- a/tests/qat/backend/qblox/test_passes.py
+++ b/tests/qat/backend/qblox/test_passes.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+
+import numpy as np
+
+from qat.backend.analysis_passes import (
+    BindingPass,
+    BindingResult,
+    IterBound,
+    TILegalisationPass,
+    TriagePass,
+    TriageResult,
+)
+from qat.backend.transform_passes import RepeatSanitisation, ScopeSanitisation
+from qat.ir.pass_base import PassManager
+from qat.ir.result_base import ResultManager
+from qat.purr.backends.echo import get_default_echo_hardware
+from qat.purr.backends.qblox.analysis_passes import QbloxLegalisationPass
+from qat.purr.backends.qblox.codegen import PreCodegenPass, PreCodegenResult
+from qat.purr.compiler.instructions import DeviceUpdate
+
+from tests.qat.utils.builder_nuggets import resonator_spect
+
+
+class TestAnalysisPasses:
+    def test_precodegen_pass(self):
+        model = get_default_echo_hardware()
+        res_mgr = ResultManager()
+        builder = resonator_spect(model)
+
+        pipeline = (
+            PassManager()
+            | RepeatSanitisation()
+            | ScopeSanitisation()
+            | TriagePass()
+            | BindingPass()
+            | TILegalisationPass()
+            | QbloxLegalisationPass()
+            | PreCodegenPass()
+        )
+
+        pipeline.run(builder, res_mgr, model)
+
+        triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
+        target_map = triage_result.target_map
+        precodegen_result: PreCodegenResult = res_mgr.lookup_by_type(PreCodegenResult)
+
+        assert precodegen_result.alloc_mgrs.keys() == target_map.keys()
+        for target, alloc_mgr in precodegen_result.alloc_mgrs.items():
+            assert len(alloc_mgr.registers) >= 2
+            assert len(alloc_mgr.labels) >= 2
+
+    def test_qblox_legalisation_pass(self):
+        model = get_default_echo_hardware()
+        builder = resonator_spect(model)
+        res_mgr = ResultManager()
+
+        (
+            PassManager()
+            | ScopeSanitisation()
+            | TriagePass()
+            | BindingPass()
+            | TILegalisationPass()
+        ).run(builder, res_mgr)
+
+        binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)
+        bounds = deepcopy(binding_result.iter_bounds)
+        QbloxLegalisationPass().run(builder, res_mgr)
+        legal_iter_bounds = binding_result.iter_bounds
+
+        assert set(legal_iter_bounds.keys()) == set(bounds.keys())
+        for target, symbol2bound in legal_iter_bounds.items():
+            for name in binding_result.symbol2scopes:
+                assert set(symbol2bound.keys()) == set(bounds[target].keys())
+                bound = bounds[target][name]
+                legal_bound = symbol2bound[name]
+                if name in binding_result.reads:
+                    device_updates = [
+                        inst
+                        for inst in binding_result.reads[name]
+                        if isinstance(inst, DeviceUpdate) and inst.target == target
+                    ]
+                    for du in device_updates:
+                        if du.attribute == "frequency":
+                            assert legal_bound != bound
+                            assert legal_bound == IterBound(
+                                start=np.array(
+                                    [QbloxLegalisationPass.freq_as_steps(bound.start)],
+                                    dtype=int,
+                                ).view(np.uint32)[0],
+                                step=np.array(
+                                    [QbloxLegalisationPass.freq_as_steps(bound.step)],
+                                    dtype=int,
+                                ).view(np.uint32)[0],
+                                end=np.array(
+                                    [QbloxLegalisationPass.freq_as_steps(bound.end)],
+                                    dtype=int,
+                                ).view(np.uint32)[0],
+                                count=bound.count,
+                            )
+                else:
+                    assert legal_bound == bound

--- a/tests/qat/qblox/test_codegen.py
+++ b/tests/qat/qblox/test_codegen.py
@@ -1,7 +1,17 @@
 import numpy as np
 import pytest
 
+from qat.backend.analysis_passes import BindingPass, CFGPass, TILegalisationPass, TriagePass
+from qat.backend.transform_passes import (
+    RepeatSanitisation,
+    ReturnSanitisation,
+    ScopeSanitisation,
+)
+from qat.ir.pass_base import InvokerMixin, PassManager
+from qat.ir.result_base import ResultManager
+from qat.purr.backends.qblox.analysis_passes import QbloxLegalisationPass
 from qat.purr.backends.qblox.codegen import (
+    NewQbloxEmitter,
     QbloxEmitter,
     get_nco_phase_arguments,
     get_nco_set_frequency_arguments,
@@ -316,3 +326,108 @@ class TestQbloxEmitter:
                 assert "play" in acquire_pkg.sequence.program
                 assert "set_awg_offs" not in acquire_pkg.sequence.program
                 assert "upd_param" not in acquire_pkg.sequence.program
+
+
+@pytest.mark.parametrize("model", [None], indirect=True)
+class TestNewQbloxEmitter(InvokerMixin):
+    def build_pass_pipeline(self, *args, **kwargs):
+        return (
+            PassManager()
+            | RepeatSanitisation()
+            | ScopeSanitisation()
+            | ReturnSanitisation()
+            | TriagePass()
+            | BindingPass()
+            | CFGPass()
+            | TILegalisationPass()
+            | QbloxLegalisationPass()
+        )
+
+    def test_compile_resonator_spect(self, model):
+        index = 0
+        qubit = model.get_qubit(index)
+        acquire_channel = qubit.get_acquire_channel()
+        res_mgr = ResultManager()
+        builder = resonator_spect(model, [index])
+        engine = model.create_engine()
+        runtime = model.create_runtime()
+        runtime.run_pass_pipeline(builder, res_mgr, model, engine)
+        self.run_pass_pipeline(builder, res_mgr, model)
+        packages = NewQbloxEmitter().emit_packages(builder, res_mgr, model)
+        assert len(packages) == 1
+        acquire_pkg = packages[0]
+        assert acquire_pkg.target == acquire_channel
+
+        measure_pulse = next(
+            (inst for inst in builder.instructions if isinstance(inst, MeasurePulse))
+        )
+        assert acquire_channel in measure_pulse.quantum_targets
+
+        assert acquire_pkg.sequence.acquisitions
+
+        assert f"freq{qubit.index}_0" in acquire_pkg.sequence.program
+
+        if measure_pulse.shape == PulseShapeType.SQUARE:
+            assert not acquire_pkg.sequence.waveforms
+            assert "play" not in acquire_pkg.sequence.program
+            assert "set_awg_offs" in acquire_pkg.sequence.program
+            assert "upd_param" in acquire_pkg.sequence.program
+        else:
+            assert acquire_pkg.sequence.waveforms
+            assert "play" in acquire_pkg.sequence.program
+            assert "set_awg_offs" not in acquire_pkg.sequence.program
+            assert "upd_param" not in acquire_pkg.sequence.program
+
+    def test_compile_qubit_spect(self, model):
+        index = 0
+        qubit = model.get_qubit(index)
+        drive_channel = qubit.get_drive_channel()
+        acquire_channel = qubit.get_acquire_channel()
+        res_mgr = ResultManager()
+        builder = qubit_spect(model, [index])
+        engine = model.create_engine()
+        runtime = model.create_runtime()
+        runtime.run_pass_pipeline(builder, res_mgr, model, engine)
+        self.run_pass_pipeline(builder, res_mgr, model)
+        packages = NewQbloxEmitter().emit_packages(builder, res_mgr, model)
+        assert len(packages) == 2
+
+        # Drive
+        drive_pkg = next((pkg for pkg in packages if pkg.target == drive_channel))
+        drive_pulse = next(
+            (inst for inst in builder.instructions if isinstance(inst, Pulse))
+        )
+        assert drive_channel in drive_pulse.quantum_targets
+
+        assert not drive_pkg.sequence.acquisitions
+
+        if drive_pulse.shape == PulseShapeType.SQUARE:
+            assert not drive_pkg.sequence.waveforms
+            assert "play" not in drive_pkg.sequence.program
+            assert "set_awg_offs" in drive_pkg.sequence.program
+            assert "upd_param" in drive_pkg.sequence.program
+        else:
+            assert drive_pkg.sequence.waveforms
+            assert "play" in drive_pkg.sequence.program
+            assert "set_awg_offs" not in drive_pkg.sequence.program
+            assert "upd_param" not in drive_pkg.sequence.program
+
+        # Readout
+        acquire_pkg = next((pkg for pkg in packages if pkg.target == acquire_channel))
+        measure_pulse = next(
+            (inst for inst in builder.instructions if isinstance(inst, MeasurePulse))
+        )
+        assert acquire_channel in measure_pulse.quantum_targets
+
+        assert acquire_pkg.sequence.acquisitions
+
+        if measure_pulse.shape == PulseShapeType.SQUARE:
+            assert not acquire_pkg.sequence.waveforms
+            assert "play" not in acquire_pkg.sequence.program
+            assert "set_awg_offs" in acquire_pkg.sequence.program
+            assert "upd_param" in acquire_pkg.sequence.program
+        else:
+            assert acquire_pkg.sequence.waveforms
+            assert "play" in acquire_pkg.sequence.program
+            assert "set_awg_offs" not in acquire_pkg.sequence.program
+            assert "upd_param" not in acquire_pkg.sequence.program

--- a/tests/qat/qblox/test_device.py
+++ b/tests/qat/qblox/test_device.py
@@ -12,7 +12,7 @@ log = get_default_logger()
 
 
 @pytest.mark.parametrize("model", [None], indirect=True)
-class TestDummyQbloxControlHardware:
+class TestQbloxControlHardware:
     def test_instruction_execution(self, model):
         amp = 1
         rise = 1.0 / 3.0

--- a/tests/qat/utils/builder_nuggets.py
+++ b/tests/qat/utils/builder_nuggets.py
@@ -58,7 +58,9 @@ def qubit_spect(model, qubit_indices=None):
     builder = get_builder(model)
     builder.synchronize([model.get_qubit(index) for index in qubit_indices])
     for index in qubit_indices:
-        builder.device_assign(model.get_qubit(index).get_drive_channel(), "scale", 1)
+        # TODO - Provide better processing of static DeviceUpdates
+        model.get_qubit(index).get_drive_channel().scale = 1
+        # builder.device_assign(model.get_qubit(index).get_drive_channel(), "scale", 1)
     builder.sweep(
         [SweepValue(f"freq{index}", scan_freqs[f"Q{index}"]) for index in qubit_indices]
     )


### PR DESCRIPTION
The [original PR](https://github.com/oqc-community/qat/pull/157) was deemed too complex and we decided to split it in three main parts. The [first part](https://github.com/oqc-community/qat/pull/216) is the pass infrastructure, the [second part](https://github.com/oqc-community/qat/pull/217) is control-flow infrastructure, and the third part leverages previous work for a faster Qblox integration. This PR covers only the third part.

- Introduces a new legalisation pass for Qblox. This pass builds upon the target-agnostic `TILegalisationPass` to finalise iterator bound conversion prior to codegen.
- The PreCodegenPass allows one to properly initialise condegen contexts prior to invoking the emitter. This has the role of early register and label allocation for the loop nests in the builder as well as for the acquisition instructions.
- New Qblox codegen becomes a mere DFS traversal on the CFG to allow for more flexibility and control.
- Code generation is a much more complex topic, but CFG traversal technique introduced here is enough for the current iteration.