### PR TITLE
Fix post-processing missing from map and add test.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ author = (
     "Daria Van Hende <dvanhende@oxfordquantumcircuits.com>, "
     "Luke Causer <lcauser@oxfordquantumcircuits.com>"
 )
-release = version = "2.2.0"
+release = version = "2.2.1"
 add_module_names = False
 autoclass_content = "both"
 smv_remote_whitelist = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "qat-compiler"
 # This name has the -compiler suffix in order to use the poetry and twine tools to build and publish to PyPI
 # witout having to manually adjust the dist file names.
-version = "2.2.0"
+version = "2.2.1"
 description = "A low-level quantum compiler and runtime which facilitates executing quantum IRs."
 readme = "README.rst"
 documentation = "https://oqc-community.github.io/qat"

--- a/src/qat/purr/compiler/instructions.py
+++ b/src/qat/purr/compiler/instructions.py
@@ -400,7 +400,7 @@ class PostProcessing(QuantumInstruction):
     """
 
     def __init__(self, acquire: Acquire, process, axes=None, args=None):
-        super().__init__()
+        super().__init__(acquire)
         if axes is not None and not isinstance(axes, List):
             axes = [axes]
 
@@ -412,11 +412,10 @@ class PostProcessing(QuantumInstruction):
         self.axes: List[ProcessAxis] = axes or []
         self.output_variable = acquire.output_variable
         self.result_needed = False
-        self._acquire = acquire
 
     @property
     def acquire(self) -> Acquire:
-        return self._acquire
+        return self.quantum_targets[0]
 
     def __repr__(self):
         axis = ",".join([axi.value for axi in self.axes])


### PR DESCRIPTION
Fixing a bug where `PostProcess` instructions were not properly mapped into channels in `engine.create_duration_timeline`. Also added a test to verify the generated timeline has the expected types.