### PR TITLE
 Make OpenPulseFeatures python 3.11+ compatible

### DIFF
--- a/src/qat/purr/integrations/features.py
+++ b/src/qat/purr/integrations/features.py
@@ -54,7 +54,7 @@ class Unit(Enum):
 
 # TODO: You don't want something lke this, just have two different objects for
 #   time/frequency.
-@dataclass
+@dataclass(frozen=True)
 class Quantity:
     amount: float
     unit: Unit
@@ -64,7 +64,7 @@ class Quantity:
         return f"{self.amount} {self.scale.value}{self.unit.value}"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Constraints:
     pulse_control_contraints: str = None
     max_scale: float = 1

--- a/tests/qat/test_integration_features.py
+++ b/tests/qat/test_integration_features.py
@@ -1,6 +1,28 @@
+import pytest
+
+from qat.purr.backends.echo import get_default_echo_hardware
+from qat.purr.backends.qiskit_simulator import get_default_qiskit_hardware
+from qat.purr.backends.realtime_chip_simulator import get_default_RTCS_hardware
 from qat.purr.integrations.features import OpenPulseFeatures
 
 
-def test_openpulsefeatures():
+@pytest.mark.parametrize(
+    "get_hardware",
+    [
+        get_default_echo_hardware,
+        get_default_qiskit_hardware,
+        get_default_RTCS_hardware,
+    ],
+)
+def test_openpulsefeatures(get_hardware):
     opf = OpenPulseFeatures()
-    assert len(opf.ports) == 0
+    opf.for_hardware(get_hardware())
+    blob = opf.to_json_dict()
+    assert ["open_pulse"] == list(blob.keys())
+    assert list(blob["open_pulse"].keys()) == [
+        "version",
+        "ports",
+        "frames",
+        "waveforms",
+        "constraints",
+    ]

--- a/tests/qat/test_integration_features.py
+++ b/tests/qat/test_integration_features.py
@@ -1,0 +1,6 @@
+from qat.purr.integrations.features import OpenPulseFeatures
+
+
+def test_openpulsefeatures():
+    opf = OpenPulseFeatures()
+    assert len(opf.ports) == 0


### PR DESCRIPTION
This fixes a bug where the OpenPulseFeatures class (which generates a json_dict describing our openpulse support on a given hardware model) was not python 3.11 compatible. This incompatibility was caused by one of it's supporting dataclasses having a default which was another (mutable) dataclass. This is not supported but was not checked until python 3.11.

Fortunately, the class(es) in question are (we believe) immutable in practice and so we have marked them immutable with the frozen=True attribute.

This was only spotted downstream because this file was not covered by tests (it wasn't even imported). I have added a basic test which fails without the fix.