### PR TITLE
Allow acquire time to be a Variable.

### DIFF
--- a/src/qat/purr/compiler/builders.py
+++ b/src/qat/purr/compiler/builders.py
@@ -830,7 +830,7 @@ class QuantumInstructionBuilder(InstructionBuilder):
                     "Wrong channel type given to acquire, please give a channel with a single qubit!"
                 )
             delay = qubits[0].measure_acquire["delay"]
-        return self.add(Acquire(channel, *args, delay, **kwargs))
+        return self.add(Acquire(channel, *args, delay=delay, **kwargs))
 
     def delay(self, target: Union[Qubit, PulseChannel], time: float):
         _, channel = self.model._resolve_qb_pulse_channel(target)

--- a/src/qat/purr/compiler/instructions.py
+++ b/src/qat/purr/compiler/instructions.py
@@ -345,7 +345,11 @@ class Acquire(QuantumComponent, QuantumInstruction):
         super().__init__(channel.full_id())
         super(QuantumComponent, self).__init__(channel)
         self.time: float = time or 1.0e-6
-        if self.time < 0:
+        if not isinstance(self.time, Variable | float):
+            raise TypeError(
+                f"Acquire time must be of type 'float' or 'Variable', got {type(self.time)}."
+            )
+        if isinstance(self.time, float) and self.time < 0:
             raise ValueError(
                 f"Acquire time {self.time} cannot be less than or equal to zero."
             )


### PR DESCRIPTION
Adjust acquire time validation to allow `Variable`.