### PR TITLE
Temporary stop releases with version mismatch.

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -65,6 +65,14 @@ jobs:
       run: echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/tags/}}" >> $GITHUB_OUTPUT
       id: extract_tag
 
+    - name: Check poetry and docs version matches tag
+      if: github.ref_type == 'tag'
+      run: | 
+        POETRY_VERSION=$(poetry version -s)
+        TAG=$(echo $GITHUB_REF | cut -d / -f 3)
+        DOCS_VERSION=$(grep -oP 'version = "\K.*?(?=")' docs/source/conf.py)
+        [[ $POETRY_VERSION = $TAG && $DOCS_VERSION = $TAG ]] 
+
     - name: Build docs - tag
       if: github.ref_type == 'tag'
       run: |

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -40,11 +40,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.x"
-    - name: Check poetry version matches tag
+    - name: Check poetry and docs version matches tag
       run: | 
         POETRY_VERSION=$(poetry version -s)
         TAG=$(echo $GITHUB_REF | cut -d / -f 3)
-        [ $POETRY_VERSION = $TAG ] 
+        DOCS_VERSION=$(grep -oP 'version = "\K.*?(?=")' docs/source/conf.py)
+        [[ $POETRY_VERSION = $TAG && $DOCS_VERSION = $TAG ]] 
     - name: Poetry install
       run: poetry install --sync
 


### PR DESCRIPTION
Temporarily block/reject releasing and publishing docs based on tags if the version tag does not match both the package version and the version referenced in the docs config.
@alillistone-OQC Would like you're input on this solution.