### PR TITLE
Resolve np.tanh warnings from soft square waveforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,6 @@ filterwarnings = [
     # Temporary default for pre-existing issues. Tickets exist for addressing these:
     # TODO: Watch Qiskit BasicSimulator file for update to the new run flow.
     'default:.*qiskit\.compiler\.assembler\.assemble:DeprecationWarning:qat.purr.integrations.qiskit',
-    # TODO: Investigate and resolve RuntimeWarning on Windows.
-    'default:.*overflow encountered in tanh:RuntimeWarning:qat.purr.backends.utilities',
     # Qiskit Experiment using deprecated version of PulseBackendConfiguration
     'default:.*qiskit\.providers\.models:DeprecationWarning:qiskit_experiments.framework.backend_data',
     # Qiskit IBM Experiment package using an old pkg_resources version

--- a/src/qat/purr/backends/utilities.py
+++ b/src/qat/purr/backends/utilities.py
@@ -297,12 +297,11 @@ class SoftSquareFunction(NumericFunction):
 
     @validate_input_array
     def eval(self, x: np.ndarray) -> np.ndarray:
-        return 0.5 * (
-            np.tanh((x + (self._width - self._rise) / 2.0) / self._rise, dtype=self._dtype)
-            - np.tanh(
-                (x - (self._width - self._rise) / 2.0) / self._rise, dtype=self._dtype
-            )
+        pulse = 0.5 * (
+            np.tanh((x.real + (self._width - self._rise) / 2.0) / self._rise)
+            - np.tanh((x.real - (self._width - self._rise) / 2.0) / self._rise)
         )
+        return pulse.astype(self._dtype)
 
 
 class SofterSquareFunction(NumericFunction):
@@ -312,13 +311,13 @@ class SofterSquareFunction(NumericFunction):
 
     @validate_input_array
     def eval(self, x: np.ndarray) -> np.ndarray:
-        pulse = np.tanh((x + self._width / 2.0 - self._rise) / self._rise) - np.tanh(
-            (x - self._width / 2.0 + self._rise) / self._rise
+        pulse = np.tanh((x.real + self._width / 2.0 - self._rise) / self._rise) - np.tanh(
+            (x.real - self._width / 2.0 + self._rise) / self._rise
         )
         if pulse.any():
             pulse -= np.min(pulse)
             pulse /= np.max(pulse)
-        return np.array(pulse, dtype=self._dtype)
+        return pulse.astype(self._dtype)
 
 
 class ExtraSoftSquareFunction(NumericFunction):
@@ -328,13 +327,13 @@ class ExtraSoftSquareFunction(NumericFunction):
 
     @validate_input_array
     def eval(self, x: np.ndarray) -> np.ndarray:
-        pulse = np.tanh((x + self._width / 2.0 - 2.0 * self._rise) / self._rise) - np.tanh(
-            (x - self._width / 2.0 + 2.0 * self._rise) / self._rise
-        )
+        pulse = np.tanh(
+            (x.real + self._width / 2.0 - 2.0 * self._rise) / self._rise
+        ) - np.tanh((x.real - self._width / 2.0 + 2.0 * self._rise) / self._rise)
         if pulse.any():
             pulse -= np.min(pulse)
             pulse /= np.max(pulse)
-        return np.array(pulse, dtype=self._dtype)
+        return pulse.astype(self._dtype)
 
 
 class SofterGaussianFunction(NumericFunction):

--- a/tests/qat/test_utilities.py
+++ b/tests/qat/test_utilities.py
@@ -7,11 +7,14 @@ import pytest
 
 from qat.purr.backends.utilities import (
     BlackmanFunction,
+    ExtraSoftSquareFunction,
     GaussianFunction,
     GaussianSquareFunction,
     GaussianZeroEdgeFunction,
     NumericFunction,
     SechFunction,
+    SofterSquareFunction,
+    SoftSquareFunction,
     SquareFunction,
     evaluate_shape,
 )
@@ -145,6 +148,23 @@ def test_sech_function(width):
     max_idx = np.argmax(y)
     assert np.isclose(x[max_idx], 0.0)
     assert all(np.isclose(y[max_idx::-1], y[max_idx:]))
+
+
+@pytest.mark.parametrize(
+    ["func", "width", "rise"],
+    product(
+        [SoftSquareFunction, SofterSquareFunction, ExtraSoftSquareFunction],
+        [0.5, 1.0, 2.0],
+        [1e-3, 1e-2, 1e-1],
+    ),
+)
+def test_soft_square_functions(func, width, rise):
+    # Tests the soft square functions
+    x = np.linspace(-1.0, 1.0, 101)
+    f = func(width, rise)
+    y = f(x).real
+    assert all(y[50] >= y.real)
+    assert all(np.isclose(y[50::-1], y[50:]))
 
 
 @pytest.mark.skip(reason="I don't know what the new results should be.")

--- a/tests/qat/test_utilities.py
+++ b/tests/qat/test_utilities.py
@@ -159,7 +159,7 @@ def test_sech_function(width):
     ),
 )
 def test_soft_square_functions(func, width, rise):
-    # Tests the soft square functions
+    # Tests the properties of soft square functions: maximum, symmetry
     x = np.linspace(-1.0, 1.0, 101)
     f = func(width, rise)
     y = f(x).real


### PR DESCRIPTION
Fix the overflow errors thrown by `np.tanh(x)` warnings in various waveforms. The error is thrown (on windows) when the argument `x` is complex with a sufficiently large real component. However, the waveforms are only evaluated against time (a real number), so treating `x` as complex is unnecessary. 

Changes:
- Call `x.real` but return the results as a complex type for consistency (there is no restriction that the waveform returned cannot be complex).
- Added some tests for affected waveforms.