### PR TITLE
Performance improvement: mid-circuit measurement validation

### DIFF
--- a/src/qat/compiler/validation_passes.py
+++ b/src/qat/compiler/validation_passes.py
@@ -129,7 +129,7 @@ class ReadoutValidation(ValidationPass):
             # Check if we've got a measure in the middle of the circuit somewhere.
             elif isinstance(inst, Acquire):
                 for qbit in model.qubits:
-                    if qbit.get_measure_channel() == inst.channel:
+                    if qbit.get_acquire_channel() == inst.channel:
                         consumed_qubits.append(qbit)
             elif isinstance(inst, Pulse):
                 # Find target qubit from instruction and check whether it's been

--- a/src/qat/compiler/validation_passes.py
+++ b/src/qat/compiler/validation_passes.py
@@ -84,7 +84,7 @@ class InstructionValidation(ValidationPass):
 
 class ReadoutValidation(ValidationPass):
     """
-    Extracted from LiveDeviceEngine.optimize()
+    Extracted from LiveDeviceEngine.validate()
     """
 
     def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
@@ -99,6 +99,7 @@ class ReadoutValidation(ValidationPass):
             )
 
         consumed_qubits: List[str] = []
+        chanbits_map = {}
         for inst in builder.instructions:
             if isinstance(inst, PostProcessing):
                 if (
@@ -134,7 +135,17 @@ class ReadoutValidation(ValidationPass):
                 # Find target qubit from instruction and check whether it's been
                 # measured already.
                 acquired_qubits = [
-                    model._resolve_qb_pulse_channel(chanbit)[0] in consumed_qubits
+                    (
+                        (
+                            chanbits_map[chanbit]
+                            if chanbit in chanbits_map
+                            else chanbits_map.setdefault(
+                                chanbit,
+                                model._resolve_qb_pulse_channel(chanbit)[0],
+                            )
+                        )
+                        in consumed_qubits
+                    )
                     for chanbit in inst.quantum_targets
                     if isinstance(chanbit, (Qubit, PulseChannel))
                 ]

--- a/src/qat/purr/backends/live.py
+++ b/src/qat/purr/backends/live.py
@@ -450,8 +450,6 @@ class LiveDeviceEngine(QuantumExecutionEngine):
                         for chanbit in inst.quantum_targets
                         if isinstance(chanbit, (Qubit, PulseChannel))
                     ]
-                    print(consumed_qubits)
-                    print(acquired_qubits)
 
                     if any(acquired_qubits):
                         raise ValueError(

--- a/src/qat/purr/backends/live.py
+++ b/src/qat/purr/backends/live.py
@@ -400,6 +400,7 @@ class LiveDeviceEngine(QuantumExecutionEngine):
             super().validate(instructions)
 
             consumed_qubits: List[str] = []
+            chanbits_map = {}
             for inst in instructions:
                 if isinstance(inst, PostProcessing):
                     if (
@@ -435,7 +436,17 @@ class LiveDeviceEngine(QuantumExecutionEngine):
                     # Find target qubit from instruction and check whether it's been
                     # measured already.
                     acquired_qubits = [
-                        self.model._resolve_qb_pulse_channel(chanbit)[0] in consumed_qubits
+                        (
+                            (
+                                chanbits_map[chanbit]
+                                if chanbit in chanbits_map
+                                else chanbits_map.setdefault(
+                                    chanbit,
+                                    self.model._resolve_qb_pulse_channel(chanbit)[0],
+                                )
+                            )
+                            in consumed_qubits
+                        )
                         for chanbit in inst.quantum_targets
                         if isinstance(chanbit, (Qubit, PulseChannel))
                     ]

--- a/src/qat/purr/backends/live.py
+++ b/src/qat/purr/backends/live.py
@@ -430,7 +430,7 @@ class LiveDeviceEngine(QuantumExecutionEngine):
                 # Check if we've got a measure in the middle of the circuit somewhere.
                 elif isinstance(inst, Acquire):
                     for qbit in self.model.qubits:
-                        if qbit.get_measure_channel() == inst.channel:
+                        if qbit.get_acquire_channel() == inst.channel:
                             consumed_qubits.append(qbit)
                 elif isinstance(inst, Pulse):
                     # Find target qubit from instruction and check whether it's been
@@ -450,6 +450,8 @@ class LiveDeviceEngine(QuantumExecutionEngine):
                         for chanbit in inst.quantum_targets
                         if isinstance(chanbit, (Qubit, PulseChannel))
                     ]
+                    print(consumed_qubits)
+                    print(acquired_qubits)
 
                     if any(acquired_qubits):
                         raise ValueError(

--- a/tests/qat/test_quantum_backend.py
+++ b/tests/qat/test_quantum_backend.py
@@ -716,3 +716,24 @@ class TestBaseQuantum:
             PhaseReset,
             *[PostProcessing] * 4,
         ]
+
+    def test_mid_circuit_validation(self):
+        """Tests that an error is thrown for mid-circuit measurements."""
+
+        hw = get_test_model()
+        engine = get_test_execution_engine(hw)
+        q0 = hw.get_qubit(0)
+        q1 = hw.get_qubit(1)
+        builder = (
+            get_builder(hw)
+            .had(q0)
+            .X(q1)
+            .measure(q0)
+            .measure(q1)
+            .cnot(q0, q1)
+            .measure(q0)
+            .measure(q1)
+        )
+        print("\n".join([str(type(inst)) for inst in builder.instructions]))
+        with pytest.raises(ValueError):
+            engine.validate(builder.instructions)

--- a/tests/qat/test_quantum_backend.py
+++ b/tests/qat/test_quantum_backend.py
@@ -734,6 +734,5 @@ class TestBaseQuantum:
             .measure(q0)
             .measure(q1)
         )
-        print("\n".join([str(type(inst)) for inst in builder.instructions]))
         with pytest.raises(ValueError):
             engine.validate(builder.instructions)

--- a/tests/qat/test_quantum_backend.py
+++ b/tests/qat/test_quantum_backend.py
@@ -717,22 +717,32 @@ class TestBaseQuantum:
             *[PostProcessing] * 4,
         ]
 
-    def test_mid_circuit_validation(self):
+    @pytest.mark.parametrize("pre_measures", [[0], [1], [0, 1]])
+    def test_mid_circuit_validation(self, pre_measures):
         """Tests that an error is thrown for mid-circuit measurements."""
 
         hw = get_test_model()
         engine = get_test_execution_engine(hw)
         q0 = hw.get_qubit(0)
         q1 = hw.get_qubit(1)
-        builder = (
-            get_builder(hw)
-            .had(q0)
-            .X(q1)
-            .measure(q0)
-            .measure(q1)
-            .cnot(q0, q1)
-            .measure(q0)
-            .measure(q1)
-        )
+        builder = get_builder(hw).had(q0).X(q1)
+        for qbit in pre_measures:
+            builder.measure(hw.get_qubit(qbit))
+        builder.cnot(q0, q1).measure(q0).measure(q1)
         with pytest.raises(ValueError):
             engine.validate(builder.instructions)
+
+    @pytest.mark.parametrize("qbit", [0, 1])
+    def test_mid_circuit_validation_pass(self, qbit):
+        """
+        Checks a circuit successfully validates when a measurement occurs on one qubit,
+        and subsequent gates on another.
+        """
+
+        hw = get_test_model()
+        engine = get_test_execution_engine(hw)
+        q0 = hw.get_qubit(qbit)
+        q1 = hw.get_qubit(1 - qbit)
+        builder = get_builder(hw).had(q0).cnot(q0, q1).measure(q1).X(q0)
+        engine.validate(builder.instructions)
+        assert True


### PR DESCRIPTION
**Context:**  validating that an instruction list does not have mid-circuit measurements is currently very expensive. It checks that there are no mid circuit measurements by iterating through the entire instruction set, and checking if a qubit has an acquire instruction appear before a pulse. To do so, it has to resolve the qubit for each pulse. However, this only needs to practically be done once per pulse channel, so we can cache the result and reuse that.

**Changes:**

- Cached the result of resolving_qb_pulse_channel for each quantum target so that it can be reused.
- Fixed an error in the validation that compared acquire and measure channels (maybe this needs to be more robust to consider *both* acquires and measures)
- Added a test to ensure mid-circuit measurements are caught.

Results in an order of magnitude improvement for validate for deep circuits (likely to be less impactful for shallow circuits)