### PR TITLE
Fix broken Qasm3 gates.

### DIFF
--- a/src/qat/purr/integrations/qasm.py
+++ b/src/qat/purr/integrations/qasm.py
@@ -856,9 +856,10 @@ class Qasm3ParserBase(AbstractParser, QASMVisitor):
         return f"{name}[{','.join([str(qb) for qb in target_qubits])}]"
 
     def _attempt_declaration(self, var: Variable, context: QasmContext):
-        if var.name in context.variables:
+        if (old_var := context.variables.get(var.name, None)) is None:
+            context.variables[var.name] = var
+        elif old_var != var:
             raise ValueError(f"Can't redeclare variable {var.name}")
-        context.variables[var.name] = var
 
     def visit_ClassicalDeclaration(
         self, node: ast.ClassicalDeclaration, context: QasmContext

--- a/tests/qat/qasm_utils.py
+++ b/tests/qat/qasm_utils.py
@@ -71,19 +71,22 @@ def parse_and_apply_optimiziations(
     return builder
 
 
+qasm3_gates = {}
+
+
 def get_default_qasm3_gate_qasms():
-    context = QasmContext()
-    Qasm3ParserBase().load_default_gates(context)
-    gate_list = []
-    for name, defi in context.gates.items():
-        needed_num_args = len(defi.arguments)
-        arg_string = (
-            "" if needed_num_args == 0 else "(" + ", ".join(["0"] * needed_num_args) + ")"
-        )
-        needed_num_qubits = len(defi.qubits)
-        N = max(needed_num_qubits, 2)
-        qubit_string = ", ".join([f"q[{i}]" for i in range(needed_num_qubits)])
-        gate_list.append(
-            f"""OPENQASM 3.0;\nbit[{N}] c;\nqubit[{N}] q;\n{name}{arg_string} {qubit_string};\nmeasure q -> c;"""
-        )
-    return gate_list
+    if len(qasm3_gates) == 0:
+        context = QasmContext()
+        Qasm3ParserBase().load_default_gates(context)
+        for name, defi in context.gates.items():
+            needed_num_args = len(defi.arguments)
+            arg_string = (
+                ""
+                if needed_num_args == 0
+                else "(" + ", ".join(["0"] * needed_num_args) + ")"
+            )
+            N = len(defi.qubits)
+            qubit_string = ", ".join([f"q[{i}]" for i in range(N)])
+            gate_string = f"{name}{arg_string} {qubit_string};"
+            qasm3_gates[name] = (N, gate_string)
+    return list(qasm3_gates.values())

--- a/tests/qat/test_qasm.py
+++ b/tests/qat/test_qasm.py
@@ -74,6 +74,7 @@ from qat.qat import execute, execute_qasm, fetch_frontend
 
 from tests.qat.qasm_utils import (
     ProgramFileType,
+    get_default_qasm3_gate_qasms,
     get_qasm2,
     get_qasm3,
     get_test_file_path,
@@ -602,6 +603,18 @@ class TestQASM3:
         assert np.isclose(pulses[1].width, 200e-9)
         assert np.isclose(pulses[1].amp, 0.5)
         assert np.isclose(pulses[1].std_dev, 20e-9)
+
+    @pytest.mark.parametrize(
+        "qasm", get_default_qasm3_gate_qasms(), ids=lambda val: val.split("\n")[-2]
+    )
+    def test_default_gates(self, qasm):
+        """Check that all default gates can be parsed."""
+        hw = get_default_echo_hardware(4)
+        parser = Qasm3Parser()
+        builder = parser.parse(hw.create_builder(), qasm)
+        assert isinstance(builder, InstructionBuilder)
+        assert len(builder.instructions) > 0
+        assert isinstance(builder.instructions[-1], Return)
 
 
 class TestExecutionFrontend:


### PR DESCRIPTION
Allow reuse of variable as long as it's the same variable. `old_var == var`