### PR TITLE
Allow patch releases

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -28,8 +28,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: check-current-branch
-    # only run if tag is present on branch 'main'
-    if: contains(${{ needs.check-current-branch.outputs.branch }}, 'main')`
+    # only run if tag is present on branch 'main' or 'patch-release'
+    if: contains(${{ needs.check-current-branch.outputs.branch }}, 'main') || contains(${{ needs.check-current-branch.outputs.branch }}, 'patch-release')
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds support for QAT admins to make hotfix-style patch releases x.y.z from a branch by allowing any tag on a branch patch-release/x.y.z to be released. Currently we only enforce that the branch contains the words patch-release. Branches containing this phrase are restricted to QAT admins by github.