### PR TITLE
Add support for patch releases

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-current-branch
     # only run if tag is present on branch 'main'
-    if: contains(${{ needs.check-current-branch.outputs.branch }}, 'main')`
+    if: contains(${{ needs.check-current-branch.outputs.branch }}, 'main') || contains(${{ needs.check-current-branch.outputs.branch }}, 'patch-release')
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds support for QAT admins to make hotfix-style patch releases x.y.z from a branch by allowing any tag on a branch patch-release/x.y.z to be released. Currently we only enforce that the branch contains the words patch-release. Branches containing this phrase are restricted to QAT admins by github.