### PR TITLE
Run build pipelien on PR to 'patch-release' branches.

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, '**patch-release**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Minimal change that makes the required checks run on PRs to `patch-release` branches, unblocking the PRs.