### PR TITLE
[EXPERIMENTAL] Skeptical static `DeviceUpdate` instructions

### DIFF
--- a/src/qat/backend/analysis_passes.py
+++ b/src/qat/backend/analysis_passes.py
@@ -72,7 +72,7 @@ class TriagePass(AnalysisPass):
                 else:
                     targets.update(inst.quantum_targets)
 
-            if isinstance(inst, DeviceUpdate):
+            if isinstance(inst, DeviceUpdate) and isinstance(inst.value, Variable):
                 reads[inst.target].add(inst.value.name)
 
         result = TriageResult()
@@ -303,7 +303,7 @@ class BindingPass(AnalysisPass):
                         ]
                 elif isinstance(inst, Acquire):
                     rw_result.writes[inst.output_variable].append(inst)
-                elif isinstance(inst, DeviceUpdate):
+                elif isinstance(inst, DeviceUpdate) and isinstance(inst.value, Variable):
                     if not (
                         inst.value.name in scoping_result.symbol2scopes
                         and [
@@ -337,7 +337,7 @@ class TILegalisationPass(AnalysisPass):
         return lo_freq, nco_freq
 
     def _legalise_bound(self, name: str, bound: IterBound, inst: Instruction):
-        if isinstance(inst, DeviceUpdate):
+        if isinstance(inst, DeviceUpdate) and isinstance(inst.value, Variable):
             if inst.attribute == "frequency":
                 if inst.target.fixed_if:
                     raise ValueError(

--- a/src/qat/purr/backends/qblox/analysis_passes.py
+++ b/src/qat/purr/backends/qblox/analysis_passes.py
@@ -39,7 +39,7 @@ class QbloxLegalisationPass(AnalysisPass):
         return steps
 
     def _legalise_bound(self, name: str, bound: IterBound, inst: Instruction):
-        if isinstance(inst, DeviceUpdate):
+        if isinstance(inst, DeviceUpdate) and isinstance(inst.value, Variable):
             if inst.attribute == "frequency":
                 legal_bound = IterBound(
                     start=self.freq_as_steps(bound.start),

--- a/src/qat/purr/backends/qblox/live.py
+++ b/src/qat/purr/backends/qblox/live.py
@@ -22,11 +22,23 @@ from qat.purr.backends.qblox.analysis_passes import QbloxLegalisationPass
 from qat.purr.backends.qblox.codegen import NewQbloxEmitter, QbloxEmitter
 from qat.purr.backends.utilities import get_axis_map
 from qat.purr.compiler.emitter import QatFile
-from qat.purr.compiler.execution import SweepIterator, _binary_average, _numpy_array_to_list
-from qat.purr.compiler.instructions import AcquireMode, IndexAccessor, Instruction, Variable
+from qat.purr.compiler.execution import (
+    DeviceInjectors,
+    SweepIterator,
+    _binary_average,
+    _numpy_array_to_list,
+)
+from qat.purr.compiler.instructions import (
+    AcquireMode,
+    DeviceUpdate,
+    IndexAccessor,
+    Instruction,
+    Variable,
+)
 from qat.purr.compiler.interrupt import Interrupt, NullInterrupt
 from qat.purr.compiler.runtime import NewQuantumRuntime
 from qat.purr.utils.logging_utils import log_duration
+from qat.utils.algorithm import stable_partition
 
 
 class QbloxLiveHardwareModel(LiveHardwareModel):
@@ -167,62 +179,75 @@ class NewQbloxLiveEngine(LiveDeviceEngine, InvokerMixin):
     def _common_execute(self, builder, interrupt: Interrupt = NullInterrupt()):
         self._model_exists()
 
-        with log_duration("Codegen run in {} seconds."):
-            res_mgr = ResultManager()
-            self.run_pass_pipeline(builder, res_mgr, self.model)
-            packages = NewQbloxEmitter().emit_packages(builder, res_mgr, self.model)
+        # TODO - A skeptical usage of DeviceInjectors on static device updates
+        # TODO - Figure out what they mean w/r to scopes and control flow
+        static_dus, builder.instructions = stable_partition(
+            builder.instructions,
+            lambda inst: isinstance(inst, DeviceUpdate)
+            and not isinstance(inst.value, Variable),
+        )
+        injectors = DeviceInjectors(static_dus)
 
-        with log_duration("QPU returned results in {} seconds."):
-            self.model.control_hardware.set_data(packages)
-            playback_results: Dict[str, np.ndarray] = (
-                self.model.control_hardware.start_playback(None, None)
-            )
+        try:
+            injectors.inject()
+            with log_duration("Codegen run in {} seconds."):
+                res_mgr = ResultManager()
+                self.run_pass_pipeline(builder, res_mgr, self.model)
+                packages = NewQbloxEmitter().emit_packages(builder, res_mgr, self.model)
 
-            # Post execution step needs a lot of work
-            # TODO - Robust batching analysis (as a pass !)
-            # TODO - Lowerability analysis pass
+            with log_duration("QPU returned results in {} seconds."):
+                self.model.control_hardware.set_data(packages)
+                playback_results: Dict[str, np.ndarray] = (
+                    self.model.control_hardware.start_playback(None, None)
+                )
 
-            triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
-            acquire_map = triage_result.acquire_map
-            pp_map = triage_result.pp_map
-            sweeps = triage_result.sweeps
+                # Post execution step needs a lot of work
+                # TODO - Robust batching analysis (as a pass !)
+                # TODO - Lowerability analysis pass
 
-            def create_sweep_iterator():
-                switerator = SweepIterator()
-                for sweep in sweeps:
-                    switerator.add_sweep(sweep)
-                return switerator
+                triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
+                acquire_map = triage_result.acquire_map
+                pp_map = triage_result.pp_map
+                sweeps = triage_result.sweeps
 
-            results = {}
-            for t, acquires in acquire_map.items():
-                switerator = create_sweep_iterator()
-                for acq in acquires:
-                    big_response = playback_results[acq.output_variable]
-                    sweep_splits = np.split(big_response, switerator.length)
-                    switerator.reset_iteration()
-                    while not switerator.is_finished():
-                        # just to advance iteration, no need for injection
-                        # TODO - A generic loop nest model. Sth similar to SweepIterator but does not mixin injection stuff
-                        switerator.do_sweep([])
-                        response = sweep_splits[switerator.current_iteration]
-                        response_axis = get_axis_map(acq.mode, response)
-                        for pp in pp_map[acq.output_variable]:
-                            response, response_axis = self.run_post_processing(
-                                pp, response, response_axis
-                            )
-                            handle = results.setdefault(
-                                acq.output_variable,
-                                np.empty(
-                                    switerator.get_results_shape(response.shape),
-                                    response.dtype,
-                                ),
-                            )
-                            switerator.insert_result_at_sweep_position(handle, response)
+                def create_sweep_iterator():
+                    switerator = SweepIterator()
+                    for sweep in sweeps:
+                        switerator.add_sweep(sweep)
+                    return switerator
 
-            results = self._process_results(results, triage_result)
-            results = self._process_assigns(results, triage_result)
+                results = {}
+                for t, acquires in acquire_map.items():
+                    switerator = create_sweep_iterator()
+                    for acq in acquires:
+                        big_response = playback_results[acq.output_variable]
+                        sweep_splits = np.split(big_response, switerator.length)
+                        switerator.reset_iteration()
+                        while not switerator.is_finished():
+                            # just to advance iteration, no need for injection
+                            # TODO - A generic loop nest model. Sth similar to SweepIterator but does not mixin injection stuff
+                            switerator.do_sweep([])
+                            response = sweep_splits[switerator.current_iteration]
+                            response_axis = get_axis_map(acq.mode, response)
+                            for pp in pp_map[acq.output_variable]:
+                                response, response_axis = self.run_post_processing(
+                                    pp, response, response_axis
+                                )
+                                handle = results.setdefault(
+                                    acq.output_variable,
+                                    np.empty(
+                                        switerator.get_results_shape(response.shape),
+                                        response.dtype,
+                                    ),
+                                )
+                                switerator.insert_result_at_sweep_position(handle, response)
 
-            return results
+                results = self._process_results(results, triage_result)
+                results = self._process_assigns(results, triage_result)
+
+                return results
+        finally:
+            injectors.revert()
 
     def _process_results(self, results, triage_result: TriageResult):
         """

--- a/tests/qat/backend/test_live.py
+++ b/tests/qat/backend/test_live.py
@@ -228,13 +228,22 @@ class TestQbloxLiveEngine:
 
 @pytest.mark.parametrize("model", [None], indirect=True)
 class TestQbloxLiveEngineAdapter:
-    def test_resonator_spect(self, model):
+    def test_engine_adapter(self, model):
         runtime = model.create_runtime()
         assert isinstance(runtime.engine, QbloxLiveEngineAdapter)
         assert isinstance(runtime.engine._legacy_engine, QbloxLiveEngine)
         assert isinstance(runtime.engine._new_engine, NewQbloxLiveEngine)
 
+    def test_resonator_spect(self, model):
+        runtime = model.create_runtime()
         runtime.engine.enable_hax = True
         builder = resonator_spect(model)
+        results = runtime.execute(builder)
+        assert results is not None
+
+    def test_qubit_spect(self, model):
+        runtime = model.create_runtime()
+        runtime.engine.enable_hax = True
+        builder = qubit_spect(model)
         results = runtime.execute(builder)
         assert results is not None

--- a/tests/qat/utils/builder_nuggets.py
+++ b/tests/qat/utils/builder_nuggets.py
@@ -58,9 +58,9 @@ def qubit_spect(model, qubit_indices=None, num_points=None):
     builder = get_builder(model)
     builder.synchronize([model.get_qubit(index) for index in qubit_indices])
     for index in qubit_indices:
-        # TODO - Provide better processing of static DeviceUpdates
-        model.get_qubit(index).get_drive_channel().scale = 1
-        # builder.device_assign(model.get_qubit(index).get_drive_channel(), "scale", 1)
+        # TODO - A skeptical usage of DeviceInjectors on static device updates
+        # TODO - Figure out what they mean w/r to scopes and control flow
+        builder.device_assign(model.get_qubit(index).get_drive_channel(), "scale", 1)
     builder.sweep(
         [SweepValue(f"freq{index}", scan_freqs[f"Q{index}"]) for index in qubit_indices]
     )


### PR DESCRIPTION
A static `DeviceUpdate` is one that updates an attribute on a target with a value that's known at compile time.

For example `DeviceUpdate(some_channel, "scale", 1)` simply assigns `1` to the attribute `scale` on target `some_channel`. But how come people use this version instead of simply saying `some_channel.scale = 1` ?

In fact, the legacy code processes `DeviceUpdate`s with a structure called `DeviceInjector` not only to "inject" (i.e. assign at runtime) but to "revert" any previous assignment(s) at "some aftermath" (*). It's the injection + reversion guarantee that appeals to people more than the direct way. Therefore `DeviceUpdate(some_channel, "scale", 1)` is roughly equivalent to sth like:

```
try:
    old_scale = some_channel.scale
    some_channel.scale = 1
finally:
    some_channel.scale = old_scale
```

or via some mechanism based on Python contexts.

Legacy code w/r to `SweepIterator` and `DeviceInjectors` worked fine because the (QAT IR) programs were simple basic blocks. In light of the recent efforts to bring control flow, analysis of these programs become (semantically) intractable. Therefore the problem being raised here is more on what static `DeviceUpdate` instructions mean globally for the QAT IR program and in awareness of control flow. Here are a few claims:

1. While they are perfectly valid instructions, people use static `DeviceUpdate`s (only) to benefit from the assignment + reversion process described above (*).
2. Programmers writing QAT IR are **likely unaware** that the position of a static `DeviceUpdate` among other instructions is ultimately important.
3. Static `DeviceUpdate`s can ultimately influence codegen. Pulse evaluation at compile time is one typical effect.

This PR only describes a peculiar case of `DeviceUpdate` in QAT IR and does not provide a definite solution. The workaround implemented in this PR assumes the claims laid out above. Here's what it contributes:

* Adapt existing analyses to recognise static `DeviceUpdate`s
* Filter out any static `DeviceUpdate`s prior to codegen
* Process static `DeviceUpdate`s globally and irrespective of any control flow considerations