### PR TITLE
[EXPERIMENTAL] Raise a meaningful error when acquisition memory is exceeded

### DIFF
--- a/src/qat/purr/backends/qblox/codegen.py
+++ b/src/qat/purr/backends/qblox/codegen.py
@@ -1208,6 +1208,14 @@ class QbloxCFGWalker(DfsTraversal):
                                 name = f"repeat_{hash(head)}"
                                 iter_bound = context.iter_bounds[name]
                                 num_bins *= iter_bound.count
+
+                        if num_bins > Constants.MAX_012_BINNED_ACQUISITIONS:
+                            raise ValueError(
+                                f"""
+                                Loop nest size would require {num_bins} acquisition memory bins which exceeds the maximum {Constants.MAX_012_BINNED_ACQUISITIONS}.
+                                Please reduce number of points or number of shots
+                                """
+                            )
                         context.iter_bounds[next_inst.output_variable] = IterBound(
                             start=0, step=1, end=num_bins, count=num_bins
                         )

--- a/src/qat/purr/backends/qblox/constants.py
+++ b/src/qat/purr/backends/qblox/constants.py
@@ -27,6 +27,12 @@ class Constants:
     """Number of registers available in the Qblox sequencers."""
     MAX_SAMPLE_SIZE_SCOPE_ACQUISITIONS: int = 16384
     """Maximal amount of scope trace acquisition datapoints returned."""
+    MAX_TOTAL_BINNED_ACQUISITIONS: int = 589824
+    MAX_012_BINNED_ACQUISITIONS: int = 1 << 17
+    MAX_345_BINNED_ACQUISITIONS: int = 1 << 16
+    """Each sequencer has 131072 bins with some caveats. If you are using all sequencers
+    you are limited to 131k bins for the first three sequencers and 65536 bins for the final
+    three to a maximum number of 589824 bins."""
     MAX_SAMPLE_SIZE_WAVEFORMS: int = 16384
     """Maximal amount of samples in the waveforms to be uploaded to a sequencer."""
     GRID_TIME = 4  # ns

--- a/tests/qat/utils/builder_nuggets.py
+++ b/tests/qat/utils/builder_nuggets.py
@@ -78,5 +78,6 @@ def qubit_spect(model, qubit_indices=None, num_points=None):
             rise=1.0 / 3.0,
         )
         builder.measure_mean_signal(qubit, output_variable=f"Q{index}")
-        builder.repeat(1000, 500e-6)
+
+    builder.repeat(1000, 500e-6)
     return builder


### PR DESCRIPTION
- Loop nest size should not exceed acquisition memory
- Raise for now but long term goal is support batching. In fact, batching might even disappear once we enable on-board post-processing
