### PR TITLE
Adjust passes to use QatIR.

### DIFF
--- a/src/qat/backend/transform_passes.py
+++ b/src/qat/backend/transform_passes.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from qat.ir.pass_base import TransformPass
+from qat.ir.pass_base import QatIR, TransformPass
 from qat.ir.result_base import ResultManager
 from qat.purr.compiler.builders import InstructionBuilder
 from qat.purr.compiler.hardware_models import QuantumHardwareModel
@@ -19,7 +19,7 @@ from qat.utils.algorithm import stable_partition
 
 class ScopeSanitisation(TransformPass):
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         """
         Bubbles up all sweeps and repeats to the beginning of the list.
         Adds delimiter instructions to the repeats and sweeps signifying the end of their scopes.
@@ -27,6 +27,10 @@ class ScopeSanitisation(TransformPass):
         Intended for legacy existing builders and the relative order of instructions guarantees backwards
         compatibility.
         """
+
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
 
         head, tail = stable_partition(
             builder.instructions, lambda inst: isinstance(inst, (Sweep, Repeat))
@@ -40,11 +44,15 @@ class ScopeSanitisation(TransformPass):
 
 
 class RepeatSanitisation(TransformPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         """
         Fixes repeat instructions if any with default values from the HW model
         Adds a repeat instructions if none is found
         """
+
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
 
         model = next((a for a in args if isinstance(a, QuantumHardwareModel)), None)
 
@@ -68,7 +76,11 @@ class RepeatSanitisation(TransformPass):
 
 
 class ReturnSanitisation(TransformPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         returns = [inst for inst in builder.instructions if isinstance(inst, Return)]
         acquires = [inst for inst in builder.instructions if isinstance(inst, Acquire)]
 
@@ -93,7 +105,11 @@ class DesugaringPass(TransformPass):
     is iteration constructs such as Sweep and Repeat.
     """
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         for inst in builder.instructions:
             if isinstance(inst, Sweep):
                 count = len(next(iter(inst.variables.values())))

--- a/src/qat/backend/validation_passes.py
+++ b/src/qat/backend/validation_passes.py
@@ -1,6 +1,6 @@
 from compiler_config.config import CompilerConfig
 
-from qat.ir.pass_base import ValidationPass
+from qat.ir.pass_base import QatIR, ValidationPass
 from qat.ir.result_base import ResultManager
 from qat.purr.compiler.builders import InstructionBuilder
 from qat.purr.compiler.hardware_models import QuantumHardwareModel
@@ -11,10 +11,14 @@ log = get_default_logger()
 
 
 class RepeatSanitisationValidation(ValidationPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         """
         Checks if the builder has a repeat instruction and warns if none exists.
         """
+
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
 
         repeats = [inst for inst in builder.instructions if isinstance(inst, Repeat)]
         if not repeats:
@@ -22,10 +26,14 @@ class RepeatSanitisationValidation(ValidationPass):
 
 
 class ReturnSanitisationValidation(ValidationPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         """
         Every builder must have a single return instruction
         """
+
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
 
         returns = [inst for inst in builder.instructions if isinstance(inst, Return)]
 
@@ -36,7 +44,11 @@ class ReturnSanitisationValidation(ValidationPass):
 
 
 class NCOFrequencyVariability(ValidationPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         model = next((a for a in args if isinstance(a, QuantumHardwareModel)), None)
 
         if not model:
@@ -59,7 +71,7 @@ class HardwareConfigValidity(ValidationPass):
         self.hardware_model = hardware_model
         self.compiler_config = compiler_config
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         self.compiler_config.validate(self.hardware_model)
 
 

--- a/src/qat/compiler/transform_passes.py
+++ b/src/qat/compiler/transform_passes.py
@@ -42,7 +42,11 @@ class PhaseOptimisation(TransformPass):
     Extracted from QuantumExecutionEngine.optimize()
     """
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         accum_phaseshifts: Dict[PulseChannel, PhaseShift] = {}
         optimized_instructions: List[Instruction] = []
         for instruction in builder.instructions:
@@ -79,7 +83,11 @@ class PostProcessingOptimisation(TransformPass):
     Better pass name/id ?
     """
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         pp_insts = [val for val in builder.instructions if isinstance(val, PostProcessing)]
         discarded = []
         for pp in pp_insts:

--- a/src/qat/compiler/validation_passes.py
+++ b/src/qat/compiler/validation_passes.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 
 from qat import qatconfig
-from qat.ir.pass_base import ValidationPass
+from qat.ir.pass_base import QatIR, ValidationPass
 from qat.ir.result_base import ResultManager
 from qat.purr.backends.live import LiveHardwareModel
 from qat.purr.compiler.builders import InstructionBuilder
@@ -28,7 +28,11 @@ class InstructionValidation(ValidationPass):
     Extracted from QuantumExecutionEngine.validate()
     """
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         engine = next((a for a in args if isinstance(a, QuantumExecutionEngine)), None)
 
         if not engine:
@@ -88,7 +92,11 @@ class ReadoutValidation(ValidationPass):
     Extracted from LiveDeviceEngine.validate()
     """
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         model = next((a for a in args if isinstance(a, QuantumHardwareModel)), None)
 
         if not model:
@@ -161,5 +169,5 @@ class ReadoutValidation(ValidationPass):
 
 
 class QasmValidation(ValidationPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         pass

--- a/src/qat/core.py
+++ b/src/qat/core.py
@@ -59,7 +59,8 @@ class QAT:
         metrics.enable(compiler_config.metrics)
         engine = self.hardware_model.create_engine()
         pipeline = self.build_pre_execute_pipeline(compiler_config)
-        pipeline.run(builder, execution_results, self.hardware_model, engine)
+        ir = QatIR(builder)
+        pipeline.run(ir, execution_results, self.hardware_model, engine)
 
         # TODO: Improve calibration handling
         calibrations = execution_results.lookup_by_type(

--- a/src/qat/ir/pass_base.py
+++ b/src/qat/ir/pass_base.py
@@ -14,9 +14,6 @@ class QatIR:
     value: Union[str, bytes, InstructionBuilder]
 
 
-IR = Union[QatIR, InstructionBuilder]
-
-
 class PassConcept(ABC):
     """
     Base class describing the abstraction of a pass.
@@ -25,7 +22,7 @@ class PassConcept(ABC):
     """
 
     @abstractmethod
-    def run(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         pass
 
 
@@ -40,7 +37,9 @@ class PassModel(PassConcept):
     def __init__(self, pass_obj):
         self._pass = pass_obj
 
-    def run(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        if not isinstance(ir, QatIR):
+            raise ValueError(f"Expeced QatIR got {type(ir)}")
         return self._pass.run(ir, res_mgr, *args, **kwargs)
 
 
@@ -67,16 +66,16 @@ class AnalysisPass(PassInfoMixin):
     The IR is imperatively left intact.
     """
 
-    def run(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         pass
 
 
 class TransformPass(PassInfoMixin):
     """
-    Base class for all passes that mutate the IR in-place.
+    Base class for all passes that mutate the QatIR in-place.
     """
 
-    def run(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         pass
 
 
@@ -89,7 +88,7 @@ class ValidationPass(PassInfoMixin):
     It can change according to circumstances.
     """
 
-    def run(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         pass
 
 
@@ -139,7 +138,7 @@ class PassManager(PassInfoMixin):
     def __init__(self):
         self.passes: List[PassModel] = []
 
-    def run(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         for p in self.passes:
             p.run(ir, res_mgr, *args, **kwargs)
 
@@ -168,5 +167,5 @@ class InvokerMixin(ABC):
     def build_pass_pipeline(self, *args, **kwargs) -> PassManager:
         pass
 
-    def run_pass_pipeline(self, ir: IR, res_mgr: ResultManager, *args, **kwargs):
+    def run_pass_pipeline(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         return self.build_pass_pipeline(*args, **kwargs).run(ir, res_mgr, *args, **kwargs)

--- a/src/qat/purr/backends/qblox/analysis_passes.py
+++ b/src/qat/purr/backends/qblox/analysis_passes.py
@@ -5,7 +5,7 @@ from typing import Dict, Set
 import numpy as np
 
 from qat.backend.analysis_passes import BindingResult, IterBound, TriageResult
-from qat.ir.pass_base import AnalysisPass
+from qat.ir.pass_base import AnalysisPass, QatIR
 from qat.ir.result_base import ResultManager
 from qat.purr.backends.qblox.constants import Constants
 from qat.purr.compiler.builders import InstructionBuilder
@@ -110,7 +110,7 @@ class QbloxLegalisationPass(AnalysisPass):
             count=legal_bound.count,
         )
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         """
         Performs target-dependent legalisation for QBlox.
 
@@ -146,6 +146,10 @@ class QbloxLegalisationPass(AnalysisPass):
         This pass performs target-dependent conversion as described in part (B). More features and adjustments
         will follow in future iterations.
         """
+
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
 
         triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
         binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)

--- a/src/qat/purr/backends/qblox/codegen.py
+++ b/src/qat/purr/backends/qblox/codegen.py
@@ -16,7 +16,7 @@ from qat.backend.analysis_passes import (
 )
 from qat.backend.codegen_base import DfsTraversal
 from qat.backend.graph import ControlFlowGraph
-from qat.ir.pass_base import AnalysisPass, InvokerMixin, PassManager
+from qat.ir.pass_base import AnalysisPass, InvokerMixin, PassManager, QatIR
 from qat.ir.result_base import ResultManager
 from qat.purr.backends.qblox.config import SequencerConfig
 from qat.purr.backends.qblox.constants import Constants
@@ -1097,12 +1097,16 @@ class PreCodegenResult:
 
 
 class PreCodegenPass(AnalysisPass):
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
         """
         Precedes assembly codegen.
         Performs a naive register allocation through a manager object.
         Computes useful information in the form of attributes.
         """
+
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
 
         triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
         binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)

--- a/src/qat/purr/backends/qblox/live.py
+++ b/src/qat/purr/backends/qblox/live.py
@@ -15,7 +15,7 @@ from qat.backend.transform_passes import (
     ReturnSanitisation,
     ScopeSanitisation,
 )
-from qat.ir.pass_base import InvokerMixin, PassManager
+from qat.ir.pass_base import InvokerMixin, PassManager, QatIR
 from qat.ir.result_base import ResultManager
 from qat.purr.backends.live import LiveDeviceEngine, LiveHardwareModel
 from qat.purr.backends.live_devices import ControlHardware
@@ -194,8 +194,9 @@ class NewQbloxLiveEngine(LiveDeviceEngine, InvokerMixin):
             injectors.inject()
             with log_duration("Codegen run in {} seconds."):
                 res_mgr = ResultManager()
-                self.run_pass_pipeline(builder, res_mgr, self.model)
-                packages = NewQbloxEmitter().emit_packages(builder, res_mgr, self.model)
+                ir = QatIR(builder)
+                self.run_pass_pipeline(ir, res_mgr, self.model)
+                packages = NewQbloxEmitter().emit_packages(ir, res_mgr, self.model)
 
             with log_duration("QPU returned results in {} seconds."):
                 self.model.control_hardware.set_data(packages)

--- a/src/qat/purr/compiler/runtime.py
+++ b/src/qat/purr/compiler/runtime.py
@@ -15,7 +15,7 @@ from compiler_config.config import (
 
 from qat.compiler.transform_passes import PhaseOptimisation, PostProcessingOptimisation
 from qat.compiler.validation_passes import InstructionValidation, ReadoutValidation
-from qat.ir.pass_base import InvokerMixin, PassManager
+from qat.ir.pass_base import InvokerMixin, PassManager, QatIR
 from qat.ir.result_base import ResultManager
 from qat.purr.compiler.builders import (
     FluidBuilderWrapper,
@@ -300,7 +300,7 @@ class NewQuantumRuntime(QuantumRuntime, InvokerMixin):
             )
 
         res_mgr = ResultManager()
-        self.run_pass_pipeline(builder, res_mgr, self.model, self.engine)
+        self.run_pass_pipeline(QatIR(builder), res_mgr, self.model, self.engine)
         results = fexecute(builder)
         results = self._transform_results(results, results_format, repeats)
         return self._apply_error_mitigation(results, builder, error_mitigation)

--- a/src/qat/runtime/analysis_passes.py
+++ b/src/qat/runtime/analysis_passes.py
@@ -3,7 +3,7 @@ from typing import List
 
 from compiler_config.config import CompilerConfig
 
-from qat.ir.pass_base import AnalysisPass
+from qat.ir.pass_base import AnalysisPass, QatIR
 from qat.ir.result_base import ResultInfoMixin, ResultManager
 from qat.purr.backends.calibrations.remote import find_calibration
 from qat.purr.compiler.builders import InstructionBuilder
@@ -19,7 +19,11 @@ class CalibrationAnalysis(AnalysisPass):
     def __init__(self, compiler_config: CompilerConfig):
         self.compiler_config = compiler_config
 
-    def run(self, builder: InstructionBuilder, res_mgr: ResultManager, *args, **kwargs):
+    def run(self, ir: QatIR, res_mgr: ResultManager, *args, **kwargs):
+        builder = ir.value
+        if not isinstance(builder, InstructionBuilder):
+            raise ValueError(f"Expected InstructionBuilder, got {type(builder)}")
+
         cal_blocks = [
             find_calibration(arg) for arg in self.compiler_config.active_calibrations
         ]

--- a/tests/qat/backend/qblox/test_passes.py
+++ b/tests/qat/backend/qblox/test_passes.py
@@ -11,7 +11,7 @@ from qat.backend.analysis_passes import (
     TriageResult,
 )
 from qat.backend.transform_passes import RepeatSanitisation, ScopeSanitisation
-from qat.ir.pass_base import PassManager
+from qat.ir.pass_base import PassManager, QatIR
 from qat.ir.result_base import ResultManager
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.backends.qblox.analysis_passes import QbloxLegalisationPass
@@ -38,7 +38,7 @@ class TestAnalysisPasses:
             | PreCodegenPass()
         )
 
-        pipeline.run(builder, res_mgr, model)
+        pipeline.run(QatIR(builder), res_mgr, model)
 
         triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
         target_map = triage_result.target_map
@@ -60,12 +60,12 @@ class TestAnalysisPasses:
             | TriagePass()
             | BindingPass()
             | TILegalisationPass()
-        ).run(builder, res_mgr)
+        ).run(QatIR(builder), res_mgr)
 
         triage_result: TriageResult = res_mgr.lookup_by_type(TriageResult)
         binding_result: BindingResult = deepcopy(res_mgr.lookup_by_type(BindingResult))
 
-        QbloxLegalisationPass().run(builder, res_mgr)
+        QbloxLegalisationPass().run(QatIR(builder), res_mgr)
 
         legal_binding_result: BindingResult = res_mgr.lookup_by_type(BindingResult)
 

--- a/tests/qat/runtime/test_runtime.py
+++ b/tests/qat/runtime/test_runtime.py
@@ -1,4 +1,4 @@
-from qat.ir.pass_base import AnalysisPass, TransformPass, ValidationPass
+from qat.ir.pass_base import AnalysisPass, QatIR, TransformPass, ValidationPass
 from qat.ir.result_base import ResultManager
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.compiler.runtime import NewQuantumRuntime
@@ -19,4 +19,4 @@ def test_new_quantum_runtime():
     assert not any([m for m in pipeline.passes if isinstance(m._pass, AnalysisPass)])
     assert any([m for m in pipeline.passes if isinstance(m._pass, TransformPass)])
     assert any([m for m in pipeline.passes if isinstance(m._pass, ValidationPass)])
-    runtime.run_pass_pipeline(builder, res_mgr, model, engine)
+    runtime.run_pass_pipeline(QatIR(builder), res_mgr, model, engine)


### PR DESCRIPTION
Use `QatIR` type as input to all passes. Allows the same pipeline to operate from QASM/QIR all the way down to the executable instructions.