### PR TITLE
[Experimental] A/B pipeline tests.

### DIFF
--- a/benchmarks/a-b_tests/test_pipeline.py
+++ b/benchmarks/a-b_tests/test_pipeline.py
@@ -1,0 +1,76 @@
+import pytest
+
+from qat import QAT
+from qat.purr.backends.echo import get_default_echo_hardware
+from qat.purr.compiler.frontends import QASMFrontend
+
+from benchmarks.utils.helpers import load_qasm
+from benchmarks.utils.models import get_mock_live_hardware
+
+experiments = {}
+
+
+def prepare_experiment(hw_key, hw, circ):
+    builder = QASMFrontend().parse(load_qasm(circ), hardware=hw)[0]
+    experiments[f"{circ}[{hw_key}]"] = {"circuit": circ, "hardware": hw, "builder": builder}
+
+
+# Two qubit benchmarks
+hardware_two_qubits = {
+    "echo": get_default_echo_hardware(2),
+    # "rtcs": get_default_RTCS_hardware(), # Simulation is too slow
+    "mock_live": get_mock_live_hardware(2),
+}
+circuits_two_qubits = ["bell_state", "2qb_random_cnot", "2qb_clifford"]
+for circ in circuits_two_qubits:
+    for hw_key, hw in hardware_two_qubits.items():
+        prepare_experiment(hw_key, hw, circ)
+
+# Ten qubit benchmarks
+hardware_ten_qubits = {
+    "echo": get_default_echo_hardware(10),
+    "mock_live": get_mock_live_hardware(10),
+}
+circuits_ten_qubits = ["10qb_ghz", "10qb_random_cnot"]
+for circ in circuits_ten_qubits:
+    for hw_key, hw in hardware_ten_qubits.items():
+        prepare_experiment(hw_key, hw, circ)
+
+
+@pytest.mark.benchmark(disable_gc=True, max_time=2, min_rounds=10, group="Pipeline:")
+@pytest.mark.parametrize("key", experiments.keys())
+@pytest.mark.parametrize("mode", ["A", "B"])
+class TestPipeline:
+    def test_compile_qasm(self, benchmark, key, mode):
+        hw = experiments[key]["hardware"]
+        circuit = load_qasm(experiments[key]["circuit"])
+
+        # Create a wrapper for the pipeline
+        def run_a():
+            QASMFrontend().parse(circuit, hw)
+
+        def run_b():
+            QAT(hw).compile(circuit)
+
+        if mode == "A":
+            benchmark(run_a)
+        else:
+            benchmark(run_b)
+        assert True
+
+    def test_execute_qasm(self, benchmark, key, mode):
+        hw = experiments[key]["hardware"]
+        builder = experiments[key]["builder"]
+
+        # Create a wrapper for the pipeline
+        def run_a():
+            QASMFrontend().execute(builder, hw)
+
+        def run_b():
+            QAT(hw).execute(builder)
+
+        if mode == "A":
+            benchmark(run_a)
+        else:
+            benchmark(run_b)
+        assert True

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "a-b_tests" in item.path.parts:
+            item.add_marker(pytest.mark.ab_test)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--ab-enable", action="store_true", default=False, help="enable A/B tests"
+    )
+    parser.addoption(
+        "--ab-skip", action="store_true", default=False, help="skip A/B tests, default"
+    )
+    parser.addoption("--ab-only", action="store_true", default=False, help="only A/B tests")
+    parser.addoption(
+        "--ab-grouping",
+        action="store_true",
+        default=False,
+        help="group benchmark results to show A/B comparison",
+    )
+
+
+def pytest_configure(config):
+    setattr(config.option, "markexpr", "not ab_test")
+    if config.option.ab_enable:
+        setattr(config.option, "markexpr", "ab_test or not ab_test")
+    if config.option.ab_only:
+        setattr(config.option, "markexpr", "ab_test")
+    if config.option.ab_grouping:
+        setattr(config.option, "benchmark_sort", "name")
+        setattr(config.option, "benchmark_group_by", "group,func,param:key")
+        setattr(config.option, "benchmark_enable", True)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,10 +1,12 @@
 import pytest
 
-from benchmarks.utils.models import get_mock_live_hardware
 from qat.purr.backends.echo import get_default_echo_hardware
 from qat.purr.backends.realtime_chip_simulator import get_default_RTCS_hardware
 from qat.purr.compiler.emitter import InstructionEmitter
 from qat.purr.compiler.frontends import QASMFrontend
+
+from benchmarks.utils.helpers import load_qasm
+from benchmarks.utils.models import get_mock_live_hardware
 
 experiments = {}
 
@@ -28,12 +30,6 @@ circuits_ten_qubits = ["10qb_ghz", "10qb_random_cnot"]
 for circ in circuits_ten_qubits:
     for hw_key, hw in hardware_ten_qubits.items():
         experiments[f"{circ}[{hw_key}]"] = (circ, hw)
-
-
-# QASM2 Benchmarks
-def load_qasm(qasm_string):
-    with open(f"benchmarks/qasm/{qasm_string}.qasm", "r") as f:
-        return f.read()
 
 
 @pytest.mark.benchmark(disable_gc=True, max_time=2, min_rounds=10)

--- a/benchmarks/utils/helpers.py
+++ b/benchmarks/utils/helpers.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+benchmarks_path = Path(__file__).parent.parent
+
+
+# QASM2 Benchmarks
+def load_qasm(qasm_string):
+    path = Path(qasm_string)
+    if not path.is_file() and not path.is_absolute():
+        path = benchmarks_path.joinpath("qasm", path)
+    with path.with_suffix(".qasm").open("r") as f:
+        return f.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ py_version = 39
 profile = "black"
 line_length = 92
 known_first_party = ["qat"]
-known_local_folder = ["tests"]
+known_local_folder = ["tests", "benchmarks"]
 
 [tool.black]
 line-length = 92
@@ -133,6 +133,9 @@ filterwarnings = [
     'default:.*invalid escape sequence:DeprecationWarning::1092',
     # The GlobalisePhasedX pass is unreliable and deprecated. Ticket added to resolve
     'default:.*GlobalisePhasedX:DeprecationWarning'
+]
+markers = [
+  "ab_test",
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Added pytest configuration to facilitate A/B benchmark testing as well as a set of A/B tests for `qat.purr` vs `QAT` operation.

Run `poetry run pytest benchmarks --ab-only --ab-grouping` to generate an A/B test report that is grouped and sorted to provide a clear overview of the A vs B performance of each benchmark.