### PR TITLE
Bump sigstore action to 3.0.0

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -99,7 +99,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
Looks like sigstore-python was installing a version of the cryptography package that was unsupported.

This was resolved here: https://github.com/sigstore/sigstore-python/commit/c5d470108ba938e6ad5053ba50a406241360eb6a

And the action was updated to reflect this: https://github.com/sigstore/gh-action-sigstore-python/pull/140/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552