### PR TITLE
Bump to 2.5.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/oqc-community/qat/blob/main/qat-logo.png
+.. image:: https://github.com/oqc-community/qat/blob/main/qat-logo.png?raw=True
   :width: 400
   :alt: QAT
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ author = (
     "Daria Van Hende <dvanhende@oxfordquantumcircuits.com>, "
     "Luke Causer <lcauser@oxfordquantumcircuits.com>"
 )
-release = version = "2.5.0"
+release = version = "2.5.1"
 add_module_names = False
 autoclass_content = "both"
 smv_remote_whitelist = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "qat-compiler"
 # This name has the -compiler suffix in order to use the poetry and twine tools to build and publish to PyPI
 # witout having to manually adjust the dist file names.
-version = "2.5.0"
+version = "2.5.1"
 description = "A low-level quantum compiler and runtime which facilitates executing quantum IRs."
 readme = "README.rst"
 documentation = "https://oqc-community.github.io/qat"


### PR DESCRIPTION
Bump to version 2.5.1

The change to the readme image url is an attempt at fixing the issue [PyPI if having fetching the logo](https://pypi.org/project/qat-compiler/2.5.0/).